### PR TITLE
feat: add permission checks to actions menu

### DIFF
--- a/frontend/src/modules/gestion_huerta/components/common/ActionsMenu.tsx
+++ b/frontend/src/modules/gestion_huerta/components/common/ActionsMenu.tsx
@@ -9,6 +9,9 @@ import {
   ListItemIcon,
   ListItemText,
 } from '@mui/material';
+import { shallowEqual, useSelector } from 'react-redux';
+import type { RootState } from '../../../../global/store/store';
+import { useAuth } from '../../../gestion_usuarios/context/AuthContext';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import EditIcon from '@mui/icons-material/Edit';
 import ArchiveIcon from '@mui/icons-material/Archive';
@@ -33,6 +36,11 @@ interface ActionsMenuProps {
   hideTemporadas?: boolean;
   labelFinalize?: string;                      // Texto personalizado para “Finalizar” o “Reactivar”
   labelTemporadas?: string;
+  permEdit?: string;
+  permFinalize?: string;
+  permArchiveOrRestore?: string;
+  permDelete?: string;
+  permTemporadas?: string;
 }
 
 const ActionsMenu: React.FC<ActionsMenuProps> = ({
@@ -50,6 +58,11 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({
   hideTemporadas = false,
   labelFinalize,
   labelTemporadas,
+  permEdit,
+  permFinalize,
+  permArchiveOrRestore,
+  permDelete,
+  permTemporadas,
 }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const openMenu = (e: React.MouseEvent<HTMLElement>) => setAnchorEl(e.currentTarget);
@@ -58,6 +71,21 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({
     closeMenu();
     fn && fn();
   };
+
+  // Permisos: replicar la lógica de PermissionButton
+  const roleRedux  = useSelector(
+    (s: RootState) => s.auth.user?.role,
+    shallowEqual
+  );
+  const permsRedux = useSelector(
+    (s: RootState) => s.auth.permissions,
+    shallowEqual
+  );
+  const { user: ctxUser, permissions: ctxPerms } = useAuth();
+  const role = roleRedux ?? ctxUser?.role;
+  const raw  = permsRedux.length ? permsRedux : ctxPerms;
+  const normalized = raw.map(p => p.includes('.') ? p.split('.').pop()! : p);
+  const hasPerm = (perm?: string) => !perm || role === 'admin' || normalized.includes(perm);
 
   return (
     <>
@@ -80,58 +108,103 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({
           - Solo se muestra si no está archivada (isArchived===false) y hideFinalize===false 
         */}
         {!hideFinalize && !isArchived && onFinalize && (
-          <MenuItem onClick={() => handle(onFinalize)}>
-            <ListItemIcon>
-              {isFinalized ? <RestartAltIcon fontSize="small" /> : <DoneAllIcon fontSize="small" />}
-            </ListItemIcon>
-            <ListItemText
-              primary={
-                labelFinalize 
-                  ? labelFinalize 
-                  : (isFinalized ? "Reactivar" : "Finalizar")
-              }
-            />
-          </MenuItem>
+          (() => {
+            const allowed = hasPerm(permFinalize);
+            return (
+              <Tooltip title={allowed ? '' : 'No tienes permiso'} disableHoverListener={allowed}>
+                <span style={{ display: 'block' }}>
+                  <MenuItem disabled={!allowed} onClick={() => handle(onFinalize)}>
+                    <ListItemIcon>
+                      {isFinalized ? <RestartAltIcon fontSize="small" /> : <DoneAllIcon fontSize="small" />}
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={
+                        labelFinalize
+                          ? labelFinalize
+                          : (isFinalized ? 'Reactivar' : 'Finalizar')
+                      }
+                    />
+                  </MenuItem>
+                </span>
+              </Tooltip>
+            );
+          })()
         )}
 
         {/* Consultar / Temporadas */}
         {!hideTemporadas && !isArchived && onTemporadas && (
-          <MenuItem onClick={() => handle(onTemporadas)}>
-            <ListItemIcon>
-              <EventNoteIcon fontSize="small" />
-            </ListItemIcon>
-            <ListItemText primary={labelTemporadas ?? 'Temporadas'} />
-          </MenuItem>
+          (() => {
+            const allowed = hasPerm(permTemporadas);
+            return (
+              <Tooltip title={allowed ? '' : 'No tienes permiso'} disableHoverListener={allowed}>
+                <span style={{ display: 'block' }}>
+                  <MenuItem disabled={!allowed} onClick={() => handle(onTemporadas)}>
+                    <ListItemIcon>
+                      <EventNoteIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary={labelTemporadas ?? 'Temporadas'} />
+                  </MenuItem>
+                </span>
+              </Tooltip>
+            );
+          })()
         )}
 
         {/* Editar */}
         {!hideEdit && !isArchived && onEdit && (
-          <MenuItem onClick={() => handle(onEdit)}>
-            <ListItemIcon>
-              <EditIcon fontSize="small" />
-            </ListItemIcon>
-            <ListItemText primary="Editar" />
-          </MenuItem>
+          (() => {
+            const allowed = hasPerm(permEdit);
+            return (
+              <Tooltip title={allowed ? '' : 'No tienes permiso'} disableHoverListener={allowed}>
+                <span style={{ display: 'block' }}>
+                  <MenuItem disabled={!allowed} onClick={() => handle(onEdit)}>
+                    <ListItemIcon>
+                      <EditIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Editar" />
+                  </MenuItem>
+                </span>
+              </Tooltip>
+            );
+          })()
         )}
 
         {/* Archivar / Restaurar */}
         {!hideArchiveToggle && onArchiveOrRestore && (
-          <MenuItem onClick={() => handle(onArchiveOrRestore)}>
-            <ListItemIcon>
-              {isArchived ? <UnarchiveIcon fontSize="small" /> : <ArchiveIcon fontSize="small" />}
-            </ListItemIcon>
-            <ListItemText primary={isArchived ? 'Restaurar' : 'Archivar'} />
-          </MenuItem>
+          (() => {
+            const allowed = hasPerm(permArchiveOrRestore);
+            return (
+              <Tooltip title={allowed ? '' : 'No tienes permiso'} disableHoverListener={allowed}>
+                <span style={{ display: 'block' }}>
+                  <MenuItem disabled={!allowed} onClick={() => handle(onArchiveOrRestore)}>
+                    <ListItemIcon>
+                      {isArchived ? <UnarchiveIcon fontSize="small" /> : <ArchiveIcon fontSize="small" />}
+                    </ListItemIcon>
+                    <ListItemText primary={isArchived ? 'Restaurar' : 'Archivar'} />
+                  </MenuItem>
+                </span>
+              </Tooltip>
+            );
+          })()
         )}
 
         {/* Eliminar */}
         {!hideDelete && isArchived && onDelete && (
-          <MenuItem onClick={() => handle(onDelete)}>
-            <ListItemIcon>
-              <DeleteIcon fontSize="small" />
-            </ListItemIcon>
-            <ListItemText primary="Eliminar" />
-          </MenuItem>
+          (() => {
+            const allowed = hasPerm(permDelete);
+            return (
+              <Tooltip title={allowed ? '' : 'No tienes permiso'} disableHoverListener={allowed}>
+                <span style={{ display: 'block' }}>
+                  <MenuItem disabled={!allowed} onClick={() => handle(onDelete)}>
+                    <ListItemIcon>
+                      <DeleteIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Eliminar" />
+                  </MenuItem>
+                </span>
+              </Tooltip>
+            );
+          })()
         )}
       </Menu>
     </>

--- a/frontend/src/modules/gestion_huerta/components/huerta/HuertaTable.tsx
+++ b/frontend/src/modules/gestion_huerta/components/huerta/HuertaTable.tsx
@@ -130,6 +130,10 @@ const HuertaTable: React.FC<Props> = ({
         onArchiveOrRestore={() => (!h.is_active ? onRestore(h) : onArchive(h))}
         onDelete={() => onDelete(h)}
         onTemporadas={!h.is_active || !onTemporadas ? undefined : () => onTemporadas(h)}
+        permEdit="change_huerta"
+        permArchiveOrRestore="archive_huerta"
+        permDelete="delete_huerta"
+        permTemporadas="view_temporada"
       />
     )}
   />

--- a/frontend/src/modules/gestion_huerta/components/propietario/PropietarioTable.tsx
+++ b/frontend/src/modules/gestion_huerta/components/propietario/PropietarioTable.tsx
@@ -97,6 +97,9 @@ const PropietarioTable: React.FC<Props> = ({
             onEdit={!isArch ? () => onEdit(p) : undefined}
             onArchiveOrRestore={() => onArchiveOrRestore(p.id, isArch)}
             onDelete={() => onDelete(p.id)}
+            permEdit="change_propietario"
+            permArchiveOrRestore="archive_propietario"
+            permDelete="delete_propietario"
           />
         );
       }}

--- a/frontend/src/modules/gestion_huerta/components/temporada/TemporadaTable.tsx
+++ b/frontend/src/modules/gestion_huerta/components/temporada/TemporadaTable.tsx
@@ -117,6 +117,10 @@ const TemporadaTable: React.FC<Props> = ({
             isArchived ? onRestore(t) : onArchive(t)
           }
           onDelete={isArchived ? () => onDelete(t) : undefined}
+          permFinalize="change_temporada"
+          permTemporadas="view_temporada"
+          permArchiveOrRestore="archive_temporada"
+          permDelete="delete_temporada"
         />
       );
     }}


### PR DESCRIPTION
## Summary
- gate ActionsMenu items behind permission checks and expose permission code props
- wire Propietario, Huerta and Temporada tables to supply required permission codes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in several files)*

------
https://chatgpt.com/codex/tasks/task_e_6892814fe6b8832caa1eba50dac97341