### PR TITLE
feat: improve cosecha management

### DIFF
--- a/frontend/src/global/store/cosechasSlice.ts
+++ b/frontend/src/global/store/cosechasSlice.ts
@@ -21,7 +21,6 @@ interface CosechasState {
   // filtros
   temporadaId: number | null;
   search: string;
-  finalizada: boolean | null;            // null=Todas, true=Finalizadas, false=En curso
   estado: 'activas' | 'archivadas' | 'todas';
 }
 
@@ -34,20 +33,19 @@ const initialState: CosechasState = {
   meta: { count: 0, next: null, previous: null },
   temporadaId: null,
   search: '',
-  finalizada: null,
   estado: 'activas',
 };
 
 // ───────────────── Thunks ─────────────────
 export const fetchCosechas = createAsyncThunk<
   { cosechas: Cosecha[]; meta: PaginationMeta; page: number },
-  { page: number; temporadaId: number; search?: string; finalizada?: boolean | null; estado?: 'activas'|'archivadas'|'todas' },
+  { page: number; temporadaId: number; search?: string; estado?: 'activas'|'archivadas'|'todas' },
   { rejectValue: Record<string, any> }
 >(
   'cosechas/fetch',
-  async ({ page, temporadaId, search, finalizada, estado }, { rejectWithValue }) => {
+  async ({ page, temporadaId, search, estado }, { rejectWithValue }) => {
     try {
-      const res = await cosechaService.list(page, temporadaId, search, finalizada ?? undefined, estado);
+      const res = await cosechaService.list(page, temporadaId, search, estado);
       handleBackendNotification(res);
       return { cosechas: res.data.cosechas, meta: res.data.meta, page };
     } catch (err: any) {
@@ -188,10 +186,6 @@ const cosechasSlice = createSlice({
       state.search = action.payload;
       state.page = 1;
     },
-    setFinalizada(state, action: PayloadAction<boolean | null>) {
-      state.finalizada = action.payload;
-      state.page = 1;
-    },
     setEstado(state, action: PayloadAction<'activas'|'archivadas'|'todas'>) {
       state.estado = action.payload;
       state.page = 1;
@@ -253,7 +247,6 @@ export const {
   setPage,
   setTemporadaId,
   setSearch,
-  setFinalizada,
   setEstado,
   clear,
 } = cosechasSlice.actions;

--- a/frontend/src/modules/gestion_huerta/components/cosecha/CosechaTable.tsx
+++ b/frontend/src/modules/gestion_huerta/components/cosecha/CosechaTable.tsx
@@ -4,6 +4,9 @@ import { TableLayout, Column } from '../../../../components/common/TableLayout';
 import { Cosecha } from '../../types/cosechaTypes';
 import ActionsMenu from '../common/ActionsMenu';
 
+const formatDate = (d: string | null) =>
+  d ? new Date(d).toLocaleDateString('es-MX', { day: 'numeric', month: 'long', year: 'numeric' }) : '—';
+
 interface Props {
   data: Cosecha[];
   page: number;
@@ -23,10 +26,15 @@ interface Props {
 
 const columns: Column<Cosecha>[] = [
   { label: 'Nombre', key: 'nombre' },
-  { 
-    label: 'Fecha inicio', 
+  {
+    label: 'Fecha inicio',
     key: 'fecha_inicio',
-    render: (c) => c.fecha_inicio ? new Date(c.fecha_inicio).toLocaleString('es-MX') : '—'
+    render: (c) => formatDate(c.fecha_inicio)
+  },
+  {
+    label: 'Fecha fin',
+    key: 'fecha_fin',
+    render: (c) => formatDate(c.fecha_fin)
   },
   {
     label: 'Estado',

--- a/frontend/src/modules/gestion_huerta/components/cosecha/CosechaToolbar.tsx
+++ b/frontend/src/modules/gestion_huerta/components/cosecha/CosechaToolbar.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
-import { Box, TextField, MenuItem, Button, InputAdornment, Chip, Tooltip } from '@mui/material';
+import { Box, TextField, Button, InputAdornment, Chip, Tooltip } from '@mui/material';
 import { Search as SearchIcon, Clear as ClearIcon, Add as AddIcon } from '@mui/icons-material';
 import { PermissionButton } from '../../../../components/common/PermissionButton';
 
 interface Props {
   searchValue: string;
   onSearchChange: (v: string) => void;
-  finalizadaFilter: boolean | null;
-  onFinalizadaChange: (v: boolean | null) => void;
-  estadoFilter: 'activas' | 'archivadas' | 'todas';
-  onEstadoChange: (v: 'activas'|'archivadas'|'todas') => void;
 
   onCreateClick?: () => void;
   canCreate?: boolean;
@@ -23,10 +19,6 @@ interface Props {
 const CosechaToolbar: React.FC<Props> = ({
   searchValue,
   onSearchChange,
-  finalizadaFilter,
-  onFinalizadaChange,
-  estadoFilter,
-  onEstadoChange,
   onCreateClick,
   canCreate = true,
   createTooltip,
@@ -62,32 +54,6 @@ const CosechaToolbar: React.FC<Props> = ({
           }}
           sx={{ minWidth: 300, flexGrow: 1 }}
         />
-
-        <TextField
-          size="small"
-          select
-          label="Finalización"
-          value={finalizadaFilter === null ? '' : String(finalizadaFilter)}
-          onChange={(e) => onFinalizadaChange(e.target.value === '' ? null : e.target.value === 'true')}
-          sx={{ width: 170 }}
-        >
-          <MenuItem value="">Todas</MenuItem>
-          <MenuItem value="false">En curso</MenuItem>
-          <MenuItem value="true">Finalizadas</MenuItem>
-        </TextField>
-
-        <TextField
-          size="small"
-          select
-          label="Archivo"
-          value={estadoFilter}
-          onChange={(e) => onEstadoChange(e.target.value as any)}
-          sx={{ width: 170 }}
-        >
-          <MenuItem value="activas">Activas</MenuItem>
-          <MenuItem value="archivadas">Archivadas</MenuItem>
-          <MenuItem value="todas">Todas</MenuItem>
-        </TextField>
 
         {onCreateClick && (
           <Tooltip title={createTooltip || ''}>

--- a/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
@@ -2,7 +2,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   Paper, Typography, Box, CircularProgress, Divider,
-  Dialog, DialogTitle, DialogContent, DialogActions, Button
+  Dialog, DialogTitle, DialogContent, DialogActions, Button,
+  Tabs, Tab,
 } from '@mui/material';
 import { motion } from 'framer-motion';
 import { useDispatch } from 'react-redux';
@@ -43,8 +44,8 @@ const Cosechas: React.FC = () => {
   // Store de cosechas
   const {
     cosechas, loading, page, meta,
-    search, finalizada, estado,
-    setPage, setTemporadaId, setSearch, setFinalizada, setEstado,
+    search, estado,
+    setPage, setTemporadaId, setSearch, setEstado,
     addCosecha, renameCosecha, removeCosecha,
     archiveCosecha, restoreCosecha, toggleFinalizada,
   } = useCosechas();
@@ -120,10 +121,9 @@ const Cosechas: React.FC = () => {
   const activeFiltersCount = useMemo(() => {
     let c = 0;
     if (search) c++;
-    if (finalizada !== null) c++;
     if (estado !== 'activas') c++; // si no es default
     return c;
-  }, [search, finalizada, estado]);
+  }, [search, estado]);
 
   const emptyMessage = useMemo(() => {
     if (!temporadaId) return 'Selecciona una temporada.';
@@ -201,7 +201,6 @@ const Cosechas: React.FC = () => {
   // Limpiar filtros
   const clearFilters = () => {
     setSearch('');
-    setFinalizada(null);
     setEstado('activas');
   };
 
@@ -233,10 +232,6 @@ const Cosechas: React.FC = () => {
         <CosechaToolbar
           searchValue={search}
           onSearchChange={setSearch}
-          finalizadaFilter={finalizada}
-          onFinalizadaChange={setFinalizada}
-          estadoFilter={estado}
-          onEstadoChange={setEstado}
           onCreateClick={temporadaId ? handleCreate : undefined}
           canCreate={puedeCrear}
           createTooltip={createTooltip}
@@ -244,6 +239,19 @@ const Cosechas: React.FC = () => {
           activeFiltersCount={activeFiltersCount}
           onClearFilters={clearFilters}
         />
+
+        {/* Tabs para estado */}
+        <Tabs
+          value={estado}
+          onChange={(_, v) => setEstado(v)}
+          textColor="primary"
+          indicatorColor="primary"
+          sx={{ mb: 3 }}
+        >
+          <Tab value="activas" label="Activas" />
+          <Tab value="archivadas" label="Archivadas" />
+          <Tab value="todas" label="Todas" />
+        </Tabs>
 
         {/* Tabla */}
         {spin ? (

--- a/frontend/src/modules/gestion_huerta/services/cosechaService.ts
+++ b/frontend/src/modules/gestion_huerta/services/cosechaService.ts
@@ -7,12 +7,10 @@ export const cosechaService = {
     page: number = 1,
     temporadaId: number,
     search?: string,
-    finalizada?: boolean,
     estado?: 'activas' | 'archivadas' | 'todas',
   ) {
     const params: Record<string, any> = { page, temporada: temporadaId };
     if (search) params.search = search;
-    if (finalizada !== undefined && finalizada !== null) params.finalizada = finalizada;
     if (estado) params.estado = estado;
 
     const { data } = await apiClient.get<{


### PR DESCRIPTION
## Summary
- add server-driven tabs for active, archived and all cosechas
- refresh list after mutations and fix rename
- improve date display in cosecha table and remove finalizada filter

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any in unrelated files)

------
https://chatgpt.com/codex/tasks/task_e_68928f464c44832ca30eb4984789a421