### PR TITLE
Evitar eliminar huerta con temporadas

### DIFF
--- a/backend/gestion_huerta/test/test_huerta_delete.py
+++ b/backend/gestion_huerta/test/test_huerta_delete.py
@@ -1,0 +1,41 @@
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from gestion_huerta.models import Propietario, Huerta, Temporada
+
+
+class HuertaDeleteValidationTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.admin = User.objects.create_user(
+            telefono='9990001111',
+            password='adminpass',
+            nombre='Admin',
+            apellido='User',
+            role='admin'
+        )
+        self.client.force_authenticate(user=self.admin)
+
+        self.propietario = Propietario.objects.create(
+            nombre='Juan',
+            apellidos='Pérez',
+            telefono='1234567890',
+            direccion='Calle 1'
+        )
+        self.huerta = Huerta.objects.create(
+            nombre='Mi huerta',
+            ubicacion='Ubicación',
+            variedades='Tomate',
+            hectareas=1.0,
+            propietario=self.propietario,
+            is_active=False
+        )
+        Temporada.objects.create(año=2024, huerta=self.huerta)
+
+    def test_huerta_with_temporadas_cannot_be_deleted(self):
+        url = reverse('huerta:huerta-detail', args=[self.huerta.id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(Huerta.objects.filter(id=self.huerta.id).exists())
+

--- a/backend/gestion_huerta/views/huerta_views.py
+++ b/backend/gestion_huerta/views/huerta_views.py
@@ -379,6 +379,12 @@ class HuertaViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.ModelViewSet)
                 data={"error": "No se puede eliminar. Tiene cosechas registradas."},
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
+        if instance.temporadas.exists():
+            return self.notify(
+                key="huerta_con_dependencias",
+                data={"error": "No se puede eliminar. Tiene temporadas registradas."},
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
         self.perform_destroy(instance)
         return self.notify(
             key="huerta_delete_success",


### PR DESCRIPTION
## Summary
- impedir eliminar huerta si tiene temporadas registradas
- agregar prueba que verifica la restricción al borrar huertas con temporadas

## Testing
- `python manage.py test --settings=agroproductores_risol.settings_test` *(falla: test_login_wrong_password: KeyError: 'success')*


------
https://chatgpt.com/codex/tasks/task_e_68937b5b48fc832ca0fac3c16f1d1295