### PR TITLE
Optimiza desarchivado de Temporada con bulk_update

### DIFF
--- a/backend/gestion_huerta/models.py
+++ b/backend/gestion_huerta/models.py
@@ -168,12 +168,17 @@ class Temporada(models.Model):
             self.is_active    = True
             self.archivado_en = None
             self.save(update_fields=['is_active', 'archivado_en'])
-            for cosecha in self.cosechas.all():
-                cosecha.is_active    = True
-                cosecha.archivado_en = None
-                cosecha.save(update_fields=['is_active', 'archivado_en'])
-                cosecha.inversiones.update(is_active=True, archivado_en=None)
-                cosecha.ventas.update(is_active=True, archivado_en=None)
+
+            cosechas = list(self.cosechas.all())
+            for c in cosechas:
+                c.is_active = True
+                c.archivado_en = None
+            from gestion_huerta.models import Cosecha  # import en runtime
+            Cosecha.objects.bulk_update(cosechas, ["is_active", "archivado_en"])
+
+            for c in cosechas:
+                c.inversiones.update(is_active=True, archivado_en=None)
+                c.ventas.update(is_active=True, archivado_en=None)
 
     def __str__(self):
         origen = self.huerta or self.huerta_rentada

--- a/backend/gestion_huerta/tests.py
+++ b/backend/gestion_huerta/tests.py
@@ -1,3 +1,101 @@
 from django.test import TestCase
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
 
-# Create your tests here.
+from .models import (
+    Propietario,
+    Huerta,
+    Temporada,
+    Cosecha,
+    CategoriaInversion,
+    InversionesHuerta,
+    Venta,
+)
+
+
+class TemporadaDesarchivarTests(TestCase):
+    def setUp(self):
+        propietario = Propietario.objects.create(
+            nombre="Pablo",
+            apellidos="Perez",
+            telefono="1234567890",
+            direccion="Dir",
+        )
+        self.huerta = Huerta.objects.create(
+            nombre="Mi Huerta",
+            ubicacion="Ubic",
+            variedades="Var",
+            historial="",
+            hectareas=1,
+            propietario=propietario,
+        )
+        self.temporada = Temporada.objects.create(año=2024, huerta=self.huerta)
+        categoria = CategoriaInversion.objects.create(nombre="Cat")
+
+        for i in range(3):
+            cosecha = Cosecha.objects.create(
+                nombre=f"C{i}",
+                temporada=self.temporada,
+                huerta=self.huerta,
+            )
+            InversionesHuerta.objects.create(
+                nombre="Inv",
+                fecha=timezone.now().date(),
+                descripcion="",
+                gastos_insumos=0,
+                gastos_mano_obra=0,
+                categoria=categoria,
+                cosecha=cosecha,
+                huerta=self.huerta,
+            )
+            Venta.objects.create(
+                cosecha=cosecha,
+                fecha_venta=timezone.now().date(),
+                num_cajas=1,
+                precio_por_caja=1,
+                tipo_mango="Ataulfo",
+                descripcion="",
+                gasto=0,
+            )
+
+        self.temporada.archivar()
+
+    def _old_desarchivar(self, temporada):
+        if not temporada.is_active:
+            temporada.is_active = True
+            temporada.archivado_en = None
+            temporada.save(update_fields=["is_active", "archivado_en"])
+            for cosecha in temporada.cosechas.all():
+                cosecha.is_active = True
+                cosecha.archivado_en = None
+                cosecha.save(update_fields=["is_active", "archivado_en"])
+                cosecha.inversiones.update(is_active=True, archivado_en=None)
+                cosecha.ventas.update(is_active=True, archivado_en=None)
+
+    def test_query_count_and_data_restored(self):
+        with CaptureQueriesContext(connection) as ctx_old:
+            self._old_desarchivar(self.temporada)
+        old_count = len(ctx_old)
+
+        self.temporada.archivar()
+
+        with CaptureQueriesContext(connection) as ctx_new:
+            self.temporada.desarchivar()
+        new_count = len(ctx_new)
+
+        self.assertLess(new_count, old_count)
+
+        self.temporada.refresh_from_db()
+        self.assertTrue(self.temporada.is_active)
+        self.assertIsNone(self.temporada.archivado_en)
+
+        for cosecha in self.temporada.cosechas.all():
+            self.assertTrue(cosecha.is_active)
+            self.assertIsNone(cosecha.archivado_en)
+            for inv in cosecha.inversiones.all():
+                self.assertTrue(inv.is_active)
+                self.assertIsNone(inv.archivado_en)
+            for venta in cosecha.ventas.all():
+                self.assertTrue(venta.is_active)
+                self.assertIsNone(venta.archivado_en)


### PR DESCRIPTION
## Summary
- Refactoriza `Temporada.desarchivar` para usar `bulk_update` y reducir consultas.
- Añade prueba que verifica la restauración de datos y menor uso de queries.

## Testing
- `python manage.py test gestion_huerta -v 2 --settings=agroproductores_risol.settings_test`


------
https://chatgpt.com/codex/tasks/task_e_68937b845c10832c8b34049c69e08238