### PR TITLE
feat: delegate cosecha naming to backend

### DIFF
--- a/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
@@ -140,17 +140,11 @@ const Cosechas: React.FC = () => {
     }
   }, [estado, temporadaId]);
 
-  // Crear cosecha auto-número
+  // Crear cosecha (el backend asigna el nombre automáticamente)
   const handleCreate = async () => {
     if (!temporadaId) return;
-    const nums = cosechas
-      .map(c => c.nombre.match(/Cosecha\s+(\d+)/i)?.[1])
-      .filter(Boolean)
-      .map(Number);
-    const next = nums.length ? Math.max(...nums) + 1 : totalCosechas + 1;
-    const nombre = `Cosecha ${next}`;
     try {
-      await addCosecha({ temporada: temporadaId, nombre });
+      await addCosecha({ temporada: temporadaId });
     } catch (e: any) {
       handleBackendNotification(e?.response?.data?.notification || e);
     }

--- a/frontend/src/modules/gestion_huerta/types/cosechaTypes.d.ts
+++ b/frontend/src/modules/gestion_huerta/types/cosechaTypes.d.ts
@@ -23,7 +23,7 @@ export interface Cosecha {
 
 export interface CosechaCreateData {
   temporada: number;     // requerido para crear
-  nombre?: string;       // opcional: podemos auto-generarlo en front
+  nombre?: string;       // opcional: el backend lo genera si se omite
 }
 
 export interface CosechaUpdateData {


### PR DESCRIPTION
## Summary
- rely on backend to generate cosecha name
- document optional nombre field in CosechaCreateData

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `python manage.py test` *(fails: Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2))*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68937bac5f80832c82e24b579d654a63