### PR TITLE
feat: delegate cosecha naming to backend

### DIFF
--- a/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
@@ -140,19 +140,15 @@ const Cosechas: React.FC = () => {
     }
   }, [estado, temporadaId]);
 
-  // Crear cosecha auto-número
+  // Crear cosecha (el backend asigna el nombre automáticamente)
   const handleCreate = async () => {
-    if (!temporadaId) return;
-    const nums = cosechas
-      .map(c => c.nombre.match(/Cosecha\s+(\d+)/i)?.[1])
-      .filter(Boolean)
-      .map(Number);
-    const next = nums.length ? Math.max(...nums) + 1 : totalCosechas + 1;
-    const nombre = `Cosecha ${next}`;
+    const temporada = tempInfo?.id;
+    if (!temporada) return;
     try {
-      await addCosecha({ temporada: temporadaId, nombre });
-    } catch (e: any) {
-      handleBackendNotification(e?.response?.data?.notification || e);
+      await addCosecha({ temporada });
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { notification?: unknown } } };
+      handleBackendNotification(err.response?.data?.notification || e);
     }
   };
 

--- a/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
@@ -145,9 +145,8 @@ const Cosechas: React.FC = () => {
     if (!temporadaId) return;
     try {
       await addCosecha({ temporada: temporadaId });
-    } catch (e: unknown) {
-      const err = e as { response?: { data?: { notification?: unknown } } };
-      handleBackendNotification(err.response?.data?.notification || e);
+    } catch (e: any) {
+      handleBackendNotification(e?.response?.data?.notification || e);
     }
   };
 

--- a/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
@@ -142,10 +142,9 @@ const Cosechas: React.FC = () => {
 
   // Crear cosecha (el backend asigna el nombre automáticamente)
   const handleCreate = async () => {
-    const temporada = tempInfo?.id;
-    if (!temporada) return;
+    if (!temporadaId) return;
     try {
-      await addCosecha({ temporada });
+      await addCosecha({ temporada: temporadaId });
     } catch (e: unknown) {
       const err = e as { response?: { data?: { notification?: unknown } } };
       handleBackendNotification(err.response?.data?.notification || e);

--- a/frontend/src/modules/gestion_huerta/types/cosechaTypes.d.ts
+++ b/frontend/src/modules/gestion_huerta/types/cosechaTypes.d.ts
@@ -23,7 +23,7 @@ export interface Cosecha {
 
 export interface CosechaCreateData {
   temporada: number;     // requerido para crear
-  nombre?: string;       // opcional: podemos auto-generarlo en front
+  nombre?: string;       // opcional: el backend lo genera si se omite
 }
 
 export interface CosechaUpdateData {


### PR DESCRIPTION
## Summary
- rely on backend to generate cosecha name
- send temporada id from loaded season info when creating a cosecha

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `python manage.py test` *(fails: No module named 'drf_spectacular')*

------
https://chatgpt.com/codex/tasks/task_e_68937bac5f80832c82e24b579d654a63