### PR TITLE
Renombrar campos de inversión y exponer gastos totales

### DIFF
--- a/frontend/src/modules/gestion_huerta/components/finanzas/InversionFormModal.tsx
+++ b/frontend/src/modules/gestion_huerta/components/finanzas/InversionFormModal.tsx
@@ -13,7 +13,7 @@ type Props = {
   open: boolean;
   onClose: () => void;
   isEdit: boolean;
-  initialValues?: Omit<InversionCreate, 'cosecha_id' | 'huerta_id'> | InversionUpdate;
+  initialValues?: Omit<InversionCreate, 'cosecha' | 'huerta'> | InversionUpdate;
   onSubmit: (payload: InversionCreate | InversionUpdate) => Promise<void>;
 
   // categorías
@@ -34,26 +34,26 @@ const schema = Yup.object({
   gastos_insumos: Yup.number().min(0, '>= 0').required('Requerido'),
   gastos_mano_obra: Yup.number().min(0, '>= 0').required('Requerido'),
   // ← Debe ser número y al menos 1 (0 es placeholder “Seleccione…”)
-  categoria_id: Yup.number().min(1, 'Selecciona una categoría').required('Requerido'),
+  categoria: Yup.number().min(1, 'Selecciona una categoría').required('Requerido'),
 });
 
 const InversionFormModal: React.FC<Props> = (p) => {
   if (!p.open) return null; // evita render cuando está cerrado
 
-  // Valores por defecto — categoria_id = 0 como placeholder
-  const defaults: Omit<InversionCreate, 'cosecha_id' | 'huerta_id'> = {
+  // Valores por defecto — categoria = 0 como placeholder
+  const defaults: Omit<InversionCreate, 'cosecha' | 'huerta'> = {
     nombre: '',
     fecha: '',
     descripcion: '',
     gastos_insumos: 0,
     gastos_mano_obra: 0,
-    categoria_id: 0,
+    categoria: 0,
   };
 
   // Si viene initialValues (edición) y no trae categoría, normalizamos a 0
   const initValues =
     p.initialValues
-      ? { ...p.initialValues, categoria_id: (p.initialValues as any).categoria_id ?? 0 }
+      ? { ...p.initialValues, categoria: (p.initialValues as any).categoria ?? 0 }
       : defaults;
 
   return (
@@ -142,16 +142,16 @@ const InversionFormModal: React.FC<Props> = (p) => {
                 {/* Select de categoría (con opción placeholder deshabilitada) */}
                 <TextField
                   label="Categoría"
-                  name="categoria_id"
+                  name="categoria"
                   select
                   SelectProps={{ native: true }}
-                  value={values.categoria_id}
+                  value={values.categoria}
                   onChange={(e) => {
                     const v = Number(e.target.value) || 0;
-                    setFieldValue('categoria_id', v);
+                    setFieldValue('categoria', v);
                   }}
-                  error={!!errors.categoria_id}
-                  helperText={(errors.categoria_id as string) || ''}
+                  error={!!errors.categoria}
+                  helperText={(errors.categoria as string) || ''}
                   fullWidth
                 >
                   <option value={0} disabled>— Selecciona categoría —</option>

--- a/frontend/src/modules/gestion_huerta/components/finanzas/InversionTable.tsx
+++ b/frontend/src/modules/gestion_huerta/components/finanzas/InversionTable.tsx
@@ -16,7 +16,7 @@ const columns: Column<Inversion>[] = [
   },
   {
     label: 'Categoría',
-    key: 'categoria_id',
+    key: 'categoria',
     render: (row) => row.categoria?.nombre || '—',
   },
   {
@@ -32,12 +32,10 @@ const columns: Column<Inversion>[] = [
     render: (row) => currency(row.gastos_mano_obra),
   },
   {
-    // ⟵ Usamos un key existente (gastos_insumos) para satisfacer Column<Inversion>,
-    // y calculamos el total en render (antes tenías "monto_total" que no existe en el tipo).
     label: 'Total',
-    key: 'gastos_insumos',
+    key: 'gastos_totales',
     align: 'right',
-    render: (row) => currency((row.gastos_insumos || 0) + (row.gastos_mano_obra || 0)),
+    render: (row) => currency(row.gastos_totales),
   },
   {
     label: 'Estado',

--- a/frontend/src/modules/gestion_huerta/pages/FinanzasPorCosecha.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/FinanzasPorCosecha.tsx
@@ -59,7 +59,7 @@ const FinanzasPorCosecha: React.FC = () => {
     const isEdit = Boolean(invEdit);
     const payload = isEdit
       ? (vals as InversionUpdate)
-      : ({ ...(vals as InversionCreate), cosecha_id: cosechaId, huerta_id: huertaId });
+      : ({ ...(vals as InversionCreate), cosecha: cosechaId, huerta: huertaId });
     const res = isEdit
       ? await inv.editInversion(invEdit.id, payload)
       : await inv.addInversion(payload as InversionCreate);
@@ -192,7 +192,7 @@ const FinanzasPorCosecha: React.FC = () => {
                         descripcion: invEdit.descripcion,
                         gastos_insumos: invEdit.gastos_insumos,
                         gastos_mano_obra: invEdit.gastos_mano_obra,
-                        categoria_id: invEdit.categoria?.id ?? null,
+                        categoria: invEdit.categoria?.id ?? null,
                       }
                     : undefined
                 }

--- a/frontend/src/modules/gestion_huerta/services/inversionService.ts
+++ b/frontend/src/modules/gestion_huerta/services/inversionService.ts
@@ -5,7 +5,7 @@ export type Estado = 'activos' | 'archivados' | 'todos';
 
 export interface InversionFilters {
   search?: string;
-  categoria_id?: number;
+  categoria?: number;
   fecha_desde?: string; // YYYY-MM-DD
   fecha_hasta?: string; // YYYY-MM-DD
 }
@@ -24,10 +24,10 @@ export const inversionService = {
     filters: InversionFilters = {}
   ): Promise<ListResp> {
     const params: Record<string, any> = { page, estado, cosecha: cosechaId };
-    if (filters.search)      params.search       = filters.search;
-    if (filters.categoria_id) params.categoria_id = filters.categoria_id;
-    if (filters.fecha_desde) params.fecha_desde   = filters.fecha_desde;
-    if (filters.fecha_hasta) params.fecha_hasta   = filters.fecha_hasta;
+    if (filters.search)    params.search     = filters.search;
+    if (filters.categoria) params.categoria  = filters.categoria;
+    if (filters.fecha_desde) params.fecha_desde = filters.fecha_desde;
+    if (filters.fecha_hasta) params.fecha_hasta = filters.fecha_hasta;
 
     const { data } = await apiClient.get<{ success: boolean; message_key: string; data: ListResp }>(
       '/huerta/inversiones/',

--- a/frontend/src/modules/gestion_huerta/types/inversionTypes.d.ts
+++ b/frontend/src/modules/gestion_huerta/types/inversionTypes.d.ts
@@ -7,10 +7,10 @@ export interface Inversion {
   gastos_mano_obra: number;
 
   // Relación y derivados
-  categoria?: { id: number; nombre: string } | null;
-  categoria_id?: number;
+  categoria: { id: number; nombre: string };
   cosecha: number; // id
   huerta: number;  // id
+  gastos_totales: number;
 
   // Estado
   is_active: boolean;
@@ -23,9 +23,9 @@ export interface InversionCreate {
   descripcion?: string | null;
   gastos_insumos: number;
   gastos_mano_obra: number;
-  categoria_id: number;
-  cosecha_id: number; // requerido por BE
-  huerta_id: number;  // requerido por BE
+  categoria: number;
+  cosecha: number; // requerido por BE
+  huerta: number;  // requerido por BE
 }
 
 export interface InversionUpdate {
@@ -34,5 +34,5 @@ export interface InversionUpdate {
   descripcion?: string | null;
   gastos_insumos?: number;
   gastos_mano_obra?: number;
-  categoria_id?: number;
+  categoria?: number;
 }


### PR DESCRIPTION
## Resumen
- Cambiado serializer de inversiones para usar `categoria`, `cosecha`, `huerta` y publicar `gastos_totales`.
- Actualizados tipos, servicios y componentes del frontend para los nuevos nombres de campos y el total calculado.

## Testing
- `python manage.py test` *(falla: Can't connect to local MySQL server)*
- `npm test` *(falla: Missing script "test" en package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689416abac3c832c8b7223edeae1dff5