### PR TITLE
fix: unify ventas endpoints

### DIFF
--- a/frontend/src/modules/gestion_huerta/services/ventaService.ts
+++ b/frontend/src/modules/gestion_huerta/services/ventaService.ts
@@ -73,7 +73,7 @@ export const ventaService = {
       success: boolean;
       notification: { key: string; message: string; type: 'success'|'error'|'warning'|'info' };
       data: ListEnvelope['data'];
-    }>('/gestion_huerta/ventas/', { params, signal: config.signal });
+    }>('/huerta/ventas/', { params, signal: config.signal });
     return data;
   },
 


### PR DESCRIPTION
## Summary
- use `/huerta/ventas/` for list endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any errors in unrelated files)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_689a9aefde74832cbc6840a18122c5c8