### PR TITLE
Fix serializer validation scope and add state checks

### DIFF
--- a/backend/gestion_huerta/serializers.py
+++ b/backend/gestion_huerta/serializers.py
@@ -457,58 +457,58 @@ class InversionesHuertaSerializer(serializers.ModelSerializer):
         return v
 
     # ——— Validación de objeto (reglas de negocio) ———
-def validate(self, data):
-    categoria       = data.get('categoria')
-    cosecha         = data.get('cosecha')
-    temporada       = data.get('temporada')
-    huerta          = data.get('huerta')
-    huerta_rentada  = data.get('huerta_rentada')
-    gi              = data.get('gastos_insumos')
-    gm              = data.get('gastos_mano_obra')
+    def validate(self, data):
+        categoria       = data.get('categoria')
+        cosecha         = data.get('cosecha')
+        temporada       = data.get('temporada')
+        huerta          = data.get('huerta')
+        huerta_rentada  = data.get('huerta_rentada')
+        gi              = data.get('gastos_insumos')
+        gm              = data.get('gastos_mano_obra')
 
-    # Totales > 0
-    if gi is not None and gm is not None:
-        if (gi + gm) <= 0:
-            raise serializers.ValidationError({"gastos_insumos": "Los gastos totales deben ser mayores a 0."})
+        # Totales > 0
+        if gi is not None and gm is not None:
+            if (gi + gm) <= 0:
+                raise serializers.ValidationError({"gastos_insumos": "Los gastos totales deben ser mayores a 0."})
 
-    # Si faltan, DRF marcará por campo
-    if not all([categoria, cosecha, temporada]):
+        # Si faltan, DRF marcará por campo
+        if not all([categoria, cosecha, temporada]):
+            return data
+
+        # Temporada debe coincidir con la de la cosecha
+        if temporada != cosecha.temporada:
+            raise serializers.ValidationError({"temporada_id": "La temporada no coincide con la temporada de la cosecha."})
+
+        # 🚫 Bloqueos por estado (pestañas duplicadas, etc.)
+        if getattr(cosecha, 'finalizada', False):
+            raise serializers.ValidationError({"cosecha_id": "No se pueden registrar inversiones en una cosecha finalizada."})
+        if not getattr(cosecha, 'is_active', True):
+            raise serializers.ValidationError({"cosecha_id": "No se pueden registrar inversiones en una cosecha archivada."})
+
+        if getattr(temporada, 'finalizada', False) or not getattr(temporada, 'is_active', True):
+            raise serializers.ValidationError({"temporada_id": "No se pueden registrar inversiones en una temporada finalizada o archivada."})
+
+        # Coherencia de origen con la cosecha
+        if cosecha.huerta_id:
+            if not huerta or huerta.id != cosecha.huerta_id:
+                raise serializers.ValidationError({"huerta_id": "La huerta no coincide con la huerta de la cosecha."})
+            if huerta_rentada is not None:
+                raise serializers.ValidationError({"huerta_rentada_id": "No asignes huerta rentada en una cosecha de huerta propia."})
+        elif cosecha.huerta_rentada_id:
+            if not huerta_rentada or huerta_rentada.id != cosecha.huerta_rentada_id:
+                raise serializers.ValidationError({"huerta_rentada_id": "La huerta rentada no coincide con la de la cosecha."})
+            if huerta is not None:
+                raise serializers.ValidationError({"huerta_id": "No asignes huerta propia en una cosecha de huerta rentada."})
+        else:
+            raise serializers.ValidationError({"cosecha_id": "La cosecha no tiene origen (huerta/huerta_rentada) definido."})
+
+        # 🚫 Origen archivado
+        if huerta and not getattr(huerta, 'is_active', True):
+            raise serializers.ValidationError({"huerta_id": "No se pueden registrar inversiones en una huerta archivada."})
+        if huerta_rentada and not getattr(huerta_rentada, 'is_active', True):
+            raise serializers.ValidationError({"huerta_rentada_id": "No se pueden registrar inversiones en una huerta rentada archivada."})
+
         return data
-
-    # Temporada debe coincidir con la de la cosecha
-    if temporada != cosecha.temporada:
-        raise serializers.ValidationError({"temporada_id": "La temporada no coincide con la temporada de la cosecha."})
-
-    # 🚫 Bloqueos por estado (pestañas duplicadas, etc.)
-    if getattr(cosecha, 'finalizada', False):
-        raise serializers.ValidationError({"cosecha_id": "No se pueden registrar inversiones en una cosecha finalizada."})
-    if not getattr(cosecha, 'is_active', True):
-        raise serializers.ValidationError({"cosecha_id": "No se pueden registrar inversiones en una cosecha archivada."})
-
-    if getattr(temporada, 'finalizada', False) or not getattr(temporada, 'is_active', True):
-        raise serializers.ValidationError({"temporada_id": "No se pueden registrar inversiones en una temporada finalizada o archivada."})
-
-    # Coherencia de origen con la cosecha
-    if cosecha.huerta_id:
-        if not huerta or huerta.id != cosecha.huerta_id:
-            raise serializers.ValidationError({"huerta_id": "La huerta no coincide con la huerta de la cosecha."})
-        if huerta_rentada is not None:
-            raise serializers.ValidationError({"huerta_rentada_id": "No asignes huerta rentada en una cosecha de huerta propia."})
-    elif cosecha.huerta_rentada_id:
-        if not huerta_rentada or huerta_rentada.id != cosecha.huerta_rentada_id:
-            raise serializers.ValidationError({"huerta_rentada_id": "La huerta rentada no coincide con la de la cosecha."})
-        if huerta is not None:
-            raise serializers.ValidationError({"huerta_id": "No asignes huerta propia en una cosecha de huerta rentada."})
-    else:
-        raise serializers.ValidationError({"cosecha_id": "La cosecha no tiene origen (huerta/huerta_rentada) definido."})
-
-    # 🚫 Origen archivado
-    if huerta and not getattr(huerta, 'is_active', True):
-        raise serializers.ValidationError({"huerta_id": "No se pueden registrar inversiones en una huerta archivada."})
-    if huerta_rentada and not getattr(huerta_rentada, 'is_active', True):
-        raise serializers.ValidationError({"huerta_rentada_id": "No se pueden registrar inversiones en una huerta rentada archivada."})
-
-    return data
 
 
 # -----------------------------
@@ -599,57 +599,56 @@ class VentaSerializer(serializers.ModelSerializer):
             if value < inicio:
                 raise serializers.ValidationError(f'La fecha debe ser igual o posterior al inicio de la cosecha ({inicio.isoformat()}).')
         return value
+    def validate(self, data):
+        cosecha, temporada, huerta, huerta_rentada = self._resolve_context_fields(data)
 
-def validate(self, data):
-    cosecha, temporada, huerta, huerta_rentada = self._resolve_context_fields(data)
+        # Coherencia temporada/cosecha
+        if temporada != cosecha.temporada:
+            raise serializers.ValidationError({'temporada_id': 'La temporada no coincide con la de la cosecha.'})
 
-    # Coherencia temporada/cosecha
-    if temporada != cosecha.temporada:
-        raise serializers.ValidationError({'temporada_id': 'La temporada no coincide con la de la cosecha.'})
+        # 🚫 Bloqueos por estado
+        if getattr(cosecha, 'finalizada', False):
+            raise serializers.ValidationError({'cosecha_id': 'No se pueden registrar/editar ventas en una cosecha finalizada.'})
+        if not getattr(cosecha, 'is_active', True):
+            raise serializers.ValidationError({'cosecha_id': 'No se pueden registrar/editar ventas en una cosecha archivada.'})
 
-    # 🚫 Bloqueos por estado
-    if getattr(cosecha, 'finalizada', False):
-        raise serializers.ValidationError({'cosecha_id': 'No se pueden registrar/editar ventas en una cosecha finalizada.'})
-    if not getattr(cosecha, 'is_active', True):
-        raise serializers.ValidationError({'cosecha_id': 'No se pueden registrar/editar ventas en una cosecha archivada.'})
+        if getattr(temporada, 'finalizada', False) or not getattr(temporada, 'is_active', True):
+            raise serializers.ValidationError({'temporada_id': 'No se pueden registrar/editar ventas en una temporada finalizada o archivada.'})
 
-    if getattr(temporada, 'finalizada', False) or not getattr(temporada, 'is_active', True):
-        raise serializers.ValidationError({'temporada_id': 'No se pueden registrar/editar ventas en una temporada finalizada o archivada.'})
+        # Coherencia de origen con la cosecha
+        if huerta and getattr(cosecha, 'huerta', None) != huerta:
+            raise serializers.ValidationError({'huerta_id': 'La huerta no coincide con la de la cosecha.'})
+        if huerta_rentada and getattr(cosecha, 'huerta_rentada', None) != huerta_rentada:
+            raise serializers.ValidationError({'huerta_rentada_id': 'La huerta rentada no coincide con la de la cosecha.'})
 
-    # Coherencia de origen con la cosecha
-    if huerta and getattr(cosecha, 'huerta', None) != huerta:
-        raise serializers.ValidationError({'huerta_id': 'La huerta no coincide con la de la cosecha.'})
-    if huerta_rentada and getattr(cosecha, 'huerta_rentada', None) != huerta_rentada:
-        raise serializers.ValidationError({'huerta_rentada_id': 'La huerta rentada no coincide con la de la cosecha.'})
+        # 🚫 Origen archivado
+        if huerta and not getattr(huerta, 'is_active', True):
+            raise serializers.ValidationError({'huerta_id': 'No se pueden registrar/editar ventas en una huerta archivada.'})
+        if huerta_rentada and not getattr(huerta_rentada, 'is_active', True):
+            raise serializers.ValidationError({'huerta_rentada_id': 'No se pueden registrar/editar ventas en una huerta rentada archivada.'})
 
-    # 🚫 Origen archivado
-    if huerta and not getattr(huerta, 'is_active', True):
-        raise serializers.ValidationError({'huerta_id': 'No se pueden registrar/editar ventas en una huerta archivada.'})
-    if huerta_rentada and not getattr(huerta_rentada, 'is_active', True):
-        raise serializers.ValidationError({'huerta_rentada_id': 'No se pueden registrar/editar ventas en una huerta rentada archivada.'})
+        # Números
+        num_cajas       = data.get('num_cajas',       getattr(self.instance, 'num_cajas',       None))
+        precio_por_caja = data.get('precio_por_caja', getattr(self.instance, 'precio_por_caja', None))
+        gasto           = data.get('gasto',           getattr(self.instance, 'gasto',           None))
 
-    # Números
-    num_cajas       = data.get('num_cajas',       getattr(self.instance, 'num_cajas',       None))
-    precio_por_caja = data.get('precio_por_caja', getattr(self.instance, 'precio_por_caja', None))
-    gasto           = data.get('gasto',           getattr(self.instance, 'gasto',           None))
+        if num_cajas is None or num_cajas <= 0:
+            raise serializers.ValidationError({'num_cajas': 'Debe ser mayor que 0.'})
+        # Modelo exige > 0
+        if precio_por_caja is None or precio_por_caja <= 0:
+            raise serializers.ValidationError({'precio_por_caja': 'Debe ser > 0.'})
+        if gasto is None or gasto < 0:
+            raise serializers.ValidationError({'gasto': 'Debe ser ≥ 0.'})
 
-    if num_cajas is None or num_cajas <= 0:
-        raise serializers.ValidationError({'num_cajas': 'Debe ser mayor que 0.'})
-    # Modelo exige > 0
-    if precio_por_caja is None or precio_por_caja <= 0:
-        raise serializers.ValidationError({'precio_por_caja': 'Debe ser > 0.'})
-    if gasto is None or gasto < 0:
-        raise serializers.ValidationError({'gasto': 'Debe ser ≥ 0.'})
+        # (Opcional) evitar ganancia negativa
+        if num_cajas is not None and precio_por_caja is not None and gasto is not None:
+            total = (num_cajas or 0) * (precio_por_caja or 0)
+            if (total - gasto) < 0:
+                raise serializers.ValidationError({'gasto': 'La ganancia neta no puede ser negativa.'})
 
-    # (Opcional) evitar ganancia negativa
-    if num_cajas is not None and precio_por_caja is not None and gasto is not None:
-        total = (num_cajas or 0) * (precio_por_caja or 0)
-        if (total - gasto) < 0:
-            raise serializers.ValidationError({'gasto': 'La ganancia neta no puede ser negativa.'})
-
-    # Inyectar contexto resuelto
-    data['cosecha']        = cosecha
-    data['temporada']      = temporada
-    data['huerta']         = huerta
-    data['huerta_rentada'] = huerta_rentada
-    return data
+        # Inyectar contexto resuelto
+        data['cosecha']        = cosecha
+        data['temporada']      = temporada
+        data['huerta']         = huerta
+        data['huerta_rentada'] = huerta_rentada
+        return data

--- a/backend/gestion_huerta/test/test_bloqueos_estado.py
+++ b/backend/gestion_huerta/test/test_bloqueos_estado.py
@@ -1,0 +1,105 @@
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from gestion_huerta.models import (
+    Propietario,
+    Huerta,
+    Temporada,
+    Cosecha,
+    CategoriaInversion,
+)
+
+
+class BloqueosEstadoTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            telefono='9999999999',
+            password='pass',
+            nombre='Admin',
+            apellido='User',
+            role='admin',
+        )
+        self.client.force_authenticate(self.user)
+
+        self.propietario = Propietario.objects.create(
+            nombre='Juan',
+            apellidos='Pérez',
+            telefono='1111111111',
+            direccion='Calle 1',
+        )
+        self.huerta = Huerta.objects.create(
+            nombre='Huerta 1',
+            ubicacion='Ubic',
+            variedades='Var',
+            hectareas=1.0,
+            propietario=self.propietario,
+        )
+        self.temporada = Temporada.objects.create(año=2024, huerta=self.huerta)
+        self.cosecha = Cosecha.objects.create(nombre='C1', temporada=self.temporada, huerta=self.huerta)
+        self.categoria = CategoriaInversion.objects.create(nombre='Cat')
+
+    def _inversion_payload(self):
+        return {
+            'fecha': timezone.localdate().isoformat(),
+            'descripcion': '',
+            'gastos_insumos': '1',
+            'gastos_mano_obra': '1',
+            'categoria_id': self.categoria.id,
+            'cosecha_id': self.cosecha.id,
+            'temporada_id': self.temporada.id,
+            'huerta_id': self.huerta.id,
+        }
+
+    def _venta_payload(self):
+        return {
+            'fecha_venta': timezone.localdate().isoformat(),
+            'tipo_mango': 'Ataulfo',
+            'num_cajas': 1,
+            'precio_por_caja': '1',
+            'gasto': '0',
+            'cosecha_id': self.cosecha.id,
+            'temporada_id': self.temporada.id,
+            'huerta_id': self.huerta.id,
+        }
+
+    def _post_inversion(self):
+        url = reverse('huerta:inversion-list')
+        return self.client.post(url, self._inversion_payload(), format='json')
+
+    def _post_venta(self):
+        url = reverse('huerta:venta-list')
+        return self.client.post(url, self._venta_payload(), format='json')
+
+    def test_archived_huerta(self):
+        self.huerta.is_active = False
+        self.huerta.save(update_fields=['is_active'])
+        self.assertEqual(self._post_inversion().status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self._post_venta().status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_archived_temporada(self):
+        self.temporada.is_active = False
+        self.temporada.save(update_fields=['is_active'])
+        self.assertEqual(self._post_inversion().status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self._post_venta().status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_finalized_temporada(self):
+        self.temporada.finalizada = True
+        self.temporada.save(update_fields=['finalizada'])
+        self.assertEqual(self._post_inversion().status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self._post_venta().status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_archived_cosecha(self):
+        self.cosecha.is_active = False
+        self.cosecha.save(update_fields=['is_active'])
+        self.assertEqual(self._post_inversion().status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self._post_venta().status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_finalized_cosecha(self):
+        self.cosecha.finalizada = True
+        self.cosecha.save(update_fields=['finalizada'])
+        self.assertEqual(self._post_inversion().status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self._post_venta().status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary
- nest `validate` methods inside `InversionesHuertaSerializer` and `VentaSerializer`
- add tests ensuring investments and sales can't be created when huerta, temporada or cosecha are archived or finalized

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python manage.py test gestion_huerta.test.test_bloqueos_estado -v 2 --settings=agroproductores_risol.settings_test`


------
https://chatgpt.com/codex/tasks/task_e_689bd253e600832c8eb83a6ef94be203