### PR TITLE
Add tests blocking investments and sales on inactive entities

### DIFF
--- a/backend/gestion_huerta/tests.py
+++ b/backend/gestion_huerta/tests.py
@@ -2,6 +2,10 @@ from django.test import TestCase
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from rest_framework.test import APIClient
 
 from .models import (
     Propietario,
@@ -96,6 +100,127 @@ class TemporadaDesarchivarTests(TestCase):
             for inv in cosecha.inversiones.all():
                 self.assertTrue(inv.is_active)
                 self.assertIsNone(inv.archivado_en)
-            for venta in cosecha.ventas.all():
-                self.assertTrue(venta.is_active)
-                self.assertIsNone(venta.archivado_en)
+        for venta in cosecha.ventas.all():
+            self.assertTrue(venta.is_active)
+            self.assertIsNone(venta.archivado_en)
+
+
+class BloqueoCreacionInversionVentaTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            telefono="9999999999",
+            password="pass",
+            nombre="Admin",
+            apellido="User",
+            role="admin",
+            is_staff=True,
+        )
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+        propietario = Propietario.objects.create(
+            nombre="Juan",
+            apellidos="Lopez",
+            telefono="1111111111",
+            direccion="Dir",
+        )
+        self.huerta = Huerta.objects.create(
+            nombre="H1",
+            ubicacion="Ubic",
+            variedades="Var",
+            historial="",
+            hectareas=1,
+            propietario=propietario,
+        )
+        self.temporada = Temporada.objects.create(año=2024, huerta=self.huerta)
+        self.cosecha = Cosecha.objects.create(
+            nombre="C1",
+            temporada=self.temporada,
+            huerta=self.huerta,
+        )
+        self.categoria = CategoriaInversion.objects.create(nombre="Cat")
+
+        today = timezone.localdate().isoformat()
+        self.inversion_data = {
+            "categoria_id": self.categoria.id,
+            "fecha": today,
+            "gastos_insumos": "100.00",
+            "gastos_mano_obra": "50.00",
+            "cosecha_id": self.cosecha.id,
+            "temporada_id": self.temporada.id,
+            "huerta_id": self.huerta.id,
+        }
+        self.venta_data = {
+            "fecha_venta": today,
+            "tipo_mango": "Ataulfo",
+            "num_cajas": 1,
+            "precio_por_caja": 1,
+            "gasto": "0",
+            "cosecha_id": self.cosecha.id,
+            "temporada_id": self.temporada.id,
+            "huerta_id": self.huerta.id,
+        }
+
+        self.inv_url = reverse("huerta:inversion-list")
+        self.venta_url = reverse("huerta:venta-list")
+
+    def _post_inversion(self):
+        return self.client.post(self.inv_url, self.inversion_data, format="json")
+
+    def _post_venta(self):
+        return self.client.post(self.venta_url, self.venta_data, format="json")
+
+    def test_bloqueo_por_huerta_archivada(self):
+        self.huerta.is_active = False
+        self.huerta.archivado_en = timezone.now()
+        self.huerta.save(update_fields=["is_active", "archivado_en"])
+
+        resp_inv = self._post_inversion()
+        self.assertEqual(resp_inv.status_code, 400)
+        self.assertIn(
+            "No se pueden registrar inversiones en una huerta archivada.",
+            resp_inv.json()["data"]["errors"]["huerta_id"][0],
+        )
+
+        resp_venta = self._post_venta()
+        self.assertEqual(resp_venta.status_code, 400)
+        self.assertIn(
+            "No se pueden registrar/editar ventas en una huerta archivada.",
+            resp_venta.json()["data"]["errors"]["huerta_id"][0],
+        )
+
+    def test_bloqueo_por_temporada_finalizada(self):
+        self.temporada.finalizar()
+
+        resp_inv = self._post_inversion()
+        self.assertEqual(resp_inv.status_code, 400)
+        self.assertIn(
+            "No se pueden registrar inversiones en una temporada finalizada o archivada.",
+            resp_inv.json()["data"]["errors"]["temporada_id"][0],
+        )
+
+        resp_venta = self._post_venta()
+        self.assertEqual(resp_venta.status_code, 400)
+        self.assertIn(
+            "No se pueden registrar/editar ventas en una temporada finalizada o archivada.",
+            resp_venta.json()["data"]["errors"]["temporada_id"][0],
+        )
+
+    def test_bloqueo_por_cosecha_finalizada(self):
+        self.cosecha.finalizar()
+
+        resp_inv = self._post_inversion()
+        self.assertEqual(resp_inv.status_code, 400)
+        self.assertIn(
+            "No se pueden registrar inversiones en una cosecha finalizada.",
+            resp_inv.json()["data"]["errors"]["cosecha_id"][0],
+        )
+
+        resp_venta = self._post_venta()
+        self.assertEqual(resp_venta.status_code, 400)
+        self.assertIn(
+            "No se pueden registrar/editar ventas en una cosecha finalizada.",
+            resp_venta.json()["data"]["errors"]["cosecha_id"][0],
+        )


### PR DESCRIPTION
## Summary
- add API tests preventing investments/ventas when huerta, temporada or cosecha are archived or finalized

## Testing
- `pytest --ds=agroproductores_risol.settings gestion_huerta/tests.py::BloqueoCreacionInversionVentaTests::test_bloqueo_por_huerta_archivada -q` *(fails: django.db.utils.OperationalError: Can't connect to local MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_689bd2555b4c832c96f28c25c5302951