### PR TITLE
feat: exclude archived owners by default in propietario search

### DIFF
--- a/frontend/src/modules/gestion_huerta/services/propietarioService.ts
+++ b/frontend/src/modules/gestion_huerta/services/propietarioService.ts
@@ -55,18 +55,25 @@ export const propietarioService = {
   },
 
   /* ------------ SOLO CON HUERTAS (con cancelación) ------------ */
-  getConHuertas(search: string, config: ReqCfg = {}) {
+  getConHuertas(
+    search: string,
+    config: ReqCfg = {},
+    includeArchived = false
+  ) {
     const params: Record<string, any> = {};
     if (search) params.search = search;
+    if (!includeArchived) params.archivado = 'false';
 
-    return apiClient.get<{
-      success: boolean;
-      message_key: string;
-      data: ListResp;
-    }>('/huerta/propietarios/solo-con-huertas/', {
-      params,
-      signal: config.signal,
-    }).then(res => res.data.data);
+    return apiClient
+      .get<{
+        success: boolean;
+        message_key: string;
+        data: ListResp;
+      }>('/huerta/propietarios/solo-con-huertas/', {
+        params,
+        signal: config.signal,
+      })
+      .then(res => res.data.data);
   },
 
   /* ------------ CREATE ------------ */
@@ -127,7 +134,8 @@ export const propietarioService = {
   /* ------------ SEARCH Autocomplete (ID o texto) ------------ */
   async searchAutocomplete(
     query: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    includeArchived = false
   ): Promise<{ label: string; value: number }[]> {
     if (!query.trim()) return [];
 
@@ -136,12 +144,15 @@ export const propietarioService = {
       return p ? [toOption(p)] : [];
     }
 
+    const params: Record<string, any> = { search: query, page_size: 50 };
+    if (!includeArchived) params.archivado = 'false';
+
     const { data } = await apiClient.get<{
       success: boolean;
       message_key: string;
       data: { propietarios: Propietario[] };
     }>('/huerta/propietarios/', {
-      params: { search: query, page_size: 50 },
+      params,
       signal,
     });
 
@@ -149,14 +160,22 @@ export const propietarioService = {
   },
 
   /* ------------ SEARCH (lista cruda) con cancelación ------------ */
-  async search(query: string, config: ReqCfg = {}): Promise<Propietario[]> {
+  async search(
+    query: string,
+    config: ReqCfg = {},
+    includeArchived = false
+  ): Promise<Propietario[]> {
     if (!query.trim()) return [];
+
+    const params: Record<string, any> = { search: query, page_size: 50 };
+    if (!includeArchived) params.archivado = 'false';
+
     const { data } = await apiClient.get<{
       success: boolean;
       message_key: string;
       data: { propietarios: Propietario[] };
     }>('/huerta/propietarios/', {
-      params: { search: query, page_size: 50 },
+      params,
       signal: config.signal,
     });
     return data.data.propietarios;


### PR DESCRIPTION
## Summary
- avoid suggesting archived propietarios unless explicitly requested
- allow including archived propietarios for advanced search
- filter propietario suggestions in huerta filters to active only

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS2307: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_689bdf29e948832c962ad21b6f5f60d8