### PR TITLE
Apply unified form validation

### DIFF
--- a/frontend/src/modules/gestion_huerta/components/finanzas/CategoriaFormModal.tsx
+++ b/frontend/src/modules/gestion_huerta/components/finanzas/CategoriaFormModal.tsx
@@ -31,8 +31,6 @@ const CategoriaFormModal: React.FC<Props> = ({ open, onClose, onSuccess, initial
         initialValues={{ nombre: initial?.nombre ?? '' }}
         validationSchema={schema}
         enableReinitialize
-        validateOnChange={false}
-        validateOnBlur={false}
         onSubmit={async (vals, helpers) => {
           try {
             const nombre = vals.nombre.trim();
@@ -47,10 +45,10 @@ const CategoriaFormModal: React.FC<Props> = ({ open, onClose, onSuccess, initial
 
             onSuccess(cat);
             onClose();
-          } catch (err: any) {
+          } catch (err: unknown) {
             const be = err?.response?.data || err?.data || {};
             const fieldErrors = be?.errors || be?.data?.errors || {};
-            Object.entries(fieldErrors).forEach(([k, v]: any) => {
+            Object.entries(fieldErrors).forEach(([k, v]: [string, unknown]) => {
               helpers.setFieldError(k, Array.isArray(v) ? v[0] : String(v));
             });
             handleBackendNotification(be);
@@ -59,7 +57,7 @@ const CategoriaFormModal: React.FC<Props> = ({ open, onClose, onSuccess, initial
           }
         }}
       >
-        {({ values, errors, handleChange, isSubmitting }) => (
+        {({ values, errors, touched, handleChange, handleBlur, isSubmitting }) => (
           <Form>
             <DialogContent dividers>
               <TextField
@@ -69,8 +67,9 @@ const CategoriaFormModal: React.FC<Props> = ({ open, onClose, onSuccess, initial
                 name="nombre"
                 value={values.nombre}
                 onChange={handleChange}
-                error={!!errors.nombre}
-                helperText={errors.nombre}
+                onBlur={handleBlur}
+                error={touched.nombre && Boolean(errors.nombre)}
+                helperText={touched.nombre && errors.nombre}
               />
             </DialogContent>
             <DialogActions>

--- a/frontend/src/modules/gestion_huerta/components/finanzas/InversionFormModal.tsx
+++ b/frontend/src/modules/gestion_huerta/components/finanzas/InversionFormModal.tsx
@@ -44,7 +44,7 @@ function formatMX(input: string | number): string {
   return Math.trunc(n).toLocaleString('es-MX', { maximumFractionDigits: 0 });
 }
 
-function msg(e: any): string {
+function msg(e: unknown): string {
   if (!e) return '';
   if (typeof e === 'string') return e;
   if (Array.isArray(e)) return e.map(x => (typeof x === 'string' ? x : '')).filter(Boolean)[0] || '';
@@ -86,7 +86,7 @@ const schema = Yup.object({
 interface Props {
   open: boolean;
   onClose: () => void;
-  onSubmit: (vals: InversionCreateData | InversionUpdateData) => Promise<any>;
+  onSubmit: (vals: InversionCreateData | InversionUpdateData) => Promise<unknown>;
   initialValues?: InversionHuerta;
 }
 
@@ -102,8 +102,8 @@ const InversionFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialV
   // abrir modal crear desde el Autocomplete (evento global)
   useEffect(() => {
     const onOpen = () => setOpenCatModal(true);
-    window.addEventListener('open-create-categoria', onOpen as any);
-    return () => window.removeEventListener('open-create-categoria', onOpen as any);
+    window.addEventListener('open-create-categoria', onOpen as EventListener);
+    return () => window.removeEventListener('open-create-categoria', onOpen as EventListener);
   }, []);
 
   const initialFormValues: FormValues = initialValues ? {
@@ -140,7 +140,7 @@ const InversionFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialV
     try {
       await onSubmit(payload);
       onClose();
-    } catch (err: any) {
+    } catch (err: unknown) {
       const backend = err?.data || err?.response?.data || {};
       const beErrors = backend.errors || backend.data?.errors || {};
       const fieldErrors: Record<string, string> = {};
@@ -151,7 +151,7 @@ const InversionFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialV
           fieldErrors[f] = msg;
         });
       }
-      Object.entries(beErrors).forEach(([f, msgVal]: [string, any]) => {
+      Object.entries(beErrors).forEach(([f, msgVal]: [string, unknown]) => {
         if (f !== 'non_field_errors') {
           const text = Array.isArray(msgVal) ? String(msgVal[0]) : String(msgVal);
           fieldErrors[f] = text;
@@ -172,7 +172,7 @@ const InversionFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialV
   const handleMoneyChange = (
     field: 'gastos_insumos' | 'gastos_mano_obra',
     raw: string,
-    setFieldValue: (f: string, v: any) => void
+    setFieldValue: (f: string, v: unknown) => void
   ) => {
     let errorMsg: string | undefined;
     // Detect invalid characters: anything other than digits, spaces or commas
@@ -218,11 +218,9 @@ const InversionFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialV
           initialValues={initialFormValues}
           enableReinitialize
           validationSchema={schema}
-          validateOnBlur={false}
-          validateOnChange={false}
           onSubmit={handleSubmit}
         >
-          {({ values, errors, isSubmitting, handleChange, setFieldValue }) => (
+          {({ values, errors, touched, isSubmitting, handleChange, handleBlur, setFieldValue }) => (
             <Form>
               <DialogContent>
                 {/* Fecha */}
@@ -232,10 +230,11 @@ const InversionFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialV
                   name="fecha"
                   value={values.fecha}
                   onChange={handleChange}
+                  onBlur={handleBlur}
                   margin="normal"
                   fullWidth
-                  error={Boolean(msg(errors.fecha))}
-                  helperText={msg(errors.fecha)}
+                  error={touched.fecha && Boolean(msg(errors.fecha))}
+                  helperText={touched.fecha && msg(errors.fecha)}
                 />
 
                 <CategoriaAutocomplete
@@ -247,10 +246,11 @@ const InversionFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialV
                     if (id) {
                       formikRef.current?.setFieldError('categoria', undefined);
                     }
+                    formikRef.current?.setFieldTouched('categoria', true, false);
                   }}
                   label="Categoría"
-                  error={Boolean(msg(errors.categoria))}
-                  helperText={msg(errors.categoria)}
+                  error={touched.categoria && Boolean(msg(errors.categoria))}
+                  helperText={touched.categoria && msg(errors.categoria)}
                 />
 
               
@@ -261,12 +261,13 @@ const InversionFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialV
                   onChange={(e) =>
                     handleMoneyChange('gastos_insumos', e.target.value, setFieldValue)
                   }
+                  onBlur={handleBlur}
                   inputMode="numeric"
                   placeholder="Ej. 12,500"
                   margin="normal"
                   fullWidth
-                  error={Boolean(msg(errors.gastos_insumos))}
-                  helperText={msg(errors.gastos_insumos)}
+                  error={touched.gastos_insumos && Boolean(msg(errors.gastos_insumos))}
+                  helperText={touched.gastos_insumos && msg(errors.gastos_insumos)}
                 />
 
                 {/* Gastos mano de obra */}
@@ -277,12 +278,13 @@ const InversionFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialV
                   onChange={(e) =>
                     handleMoneyChange('gastos_mano_obra', e.target.value, setFieldValue)
                   }
+                  onBlur={handleBlur}
                   inputMode="numeric"
                   placeholder="Ej. 8,000"
                   margin="normal"
                   fullWidth
-                  error={Boolean(msg(errors.gastos_mano_obra))}
-                  helperText={msg(errors.gastos_mano_obra)}
+                  error={touched.gastos_mano_obra && Boolean(msg(errors.gastos_mano_obra))}
+                  helperText={touched.gastos_mano_obra && msg(errors.gastos_mano_obra)}
                 />
 
                 {/* Descripción */}
@@ -291,12 +293,13 @@ const InversionFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialV
                   name="descripcion"
                   value={values.descripcion}
                   onChange={handleChange}
+                  onBlur={handleBlur}
                   margin="normal"
                   fullWidth
                   multiline
                   rows={2}
-                  error={Boolean(msg(errors.descripcion))}
-                  helperText={msg(errors.descripcion)}
+                  error={touched.descripcion && Boolean(msg(errors.descripcion))}
+                  helperText={touched.descripcion && msg(errors.descripcion)}
                 />
               </DialogContent>
               <DialogActions>

--- a/frontend/src/modules/gestion_huerta/components/finanzas/VentaFormModal.tsx
+++ b/frontend/src/modules/gestion_huerta/components/finanzas/VentaFormModal.tsx
@@ -1,5 +1,4 @@
 // src/modules/gestion_huerta/components/finanzas/VentaFormModal.tsx
-/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useRef } from 'react';
 import {
   Dialog, DialogTitle, DialogContent, DialogActions,
@@ -41,7 +40,7 @@ function formatMX(input: string | number): string {
   return Math.trunc(n).toLocaleString('es-MX', { maximumFractionDigits: 0 });
 }
 
-function msg(e: any): string {
+function msg(e: unknown): string {
   if (!e) return '';
   if (typeof e === 'string') return e;
   if (Array.isArray(e)) return e.map(x => (typeof x === 'string' ? x : '')).filter(Boolean)[0] || '';
@@ -100,7 +99,7 @@ const schema = Yup.object({
 interface Props {
   open: boolean;
   onClose: () => void;
-  onSubmit: (vals: VentaCreateData | VentaUpdateData) => Promise<any>;
+  onSubmit: (vals: VentaCreateData | VentaUpdateData) => Promise<unknown>;
   initialValues?: VentaHuerta;
 }
 
@@ -146,7 +145,7 @@ const VentaFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialValue
     try {
       await onSubmit(payload);
       onClose();
-    } catch (err: any) {
+    } catch (err: unknown) {
       const backend = err?.data || err?.response?.data || {};
       const beErrors = backend.errors || backend.data?.errors || {};
       const fieldErrors: Record<string, string> = {};
@@ -160,7 +159,7 @@ const VentaFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialValue
       }
 
       // Mapear nombres de backend → nombres del form
-      Object.entries(beErrors).forEach(([f, val]: [string, any]) => {
+      Object.entries(beErrors).forEach(([f, val]: [string, unknown]) => {
         const text = Array.isArray(val) ? String(val[0]) : String(val);
         switch (f) {
           case 'fecha':
@@ -193,7 +192,7 @@ const VentaFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialValue
   const handleMoneyChange = (
     field: 'num_cajas' | 'precio_por_caja' | 'gasto',
     raw: string,
-    setFieldValue: (f: string, v: any) => void
+    setFieldValue: (f: string, v: unknown) => void
   ) => {
     let errorMsg: string | undefined;
 
@@ -237,11 +236,9 @@ const VentaFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialValue
         initialValues={initialFormValues}
         enableReinitialize
         validationSchema={schema}
-        validateOnBlur={false}
-        validateOnChange={false}
         onSubmit={handleSubmit}
       >
-        {({ values, errors, isSubmitting, handleChange, setFieldValue }) => (
+        {({ values, errors, touched, isSubmitting, handleChange, handleBlur, setFieldValue }) => (
           <Form>
             <DialogContent>
 
@@ -255,10 +252,11 @@ const VentaFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialValue
                   setFieldValue('fecha_venta', e.target.value);
                   formikRef.current?.setFieldError('fecha_venta', undefined);
                 }}
+                onBlur={handleBlur}
                 margin="normal"
                 fullWidth
-                error={Boolean(msg(errors.fecha_venta))}
-                helperText={msg(errors.fecha_venta)}
+                error={touched.fecha_venta && Boolean(msg(errors.fecha_venta))}
+                helperText={touched.fecha_venta && msg(errors.fecha_venta)}
                 InputLabelProps={{ shrink: true }}
               />
 
@@ -271,11 +269,12 @@ const VentaFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialValue
                   setFieldValue('tipo_mango', e.target.value);
                   formikRef.current?.setFieldError('tipo_mango', undefined);
                 }}
+                onBlur={handleBlur}
                 margin="normal"
                 fullWidth
                 placeholder="Ej. Ataulfo, Kent, Tommy Atkins…"
-                error={Boolean(msg(errors.tipo_mango))}
-                helperText={msg(errors.tipo_mango)}
+                error={touched.tipo_mango && Boolean(msg(errors.tipo_mango))}
+                helperText={touched.tipo_mango && msg(errors.tipo_mango)}
               />
 
               {/* Número de cajas */}
@@ -284,12 +283,13 @@ const VentaFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialValue
                 name="num_cajas"
                 value={values.num_cajas}
                 onChange={(e) => handleMoneyChange('num_cajas', e.target.value, setFieldValue)}
+                onBlur={handleBlur}
                 inputMode="numeric"
                 placeholder="Ej. 320"
                 margin="normal"
                 fullWidth
-                error={Boolean(msg(errors.num_cajas))}
-                helperText={msg(errors.num_cajas)}
+                error={touched.num_cajas && Boolean(msg(errors.num_cajas))}
+                helperText={touched.num_cajas && msg(errors.num_cajas)}
               />
 
               {/* Precio por caja */}
@@ -298,12 +298,13 @@ const VentaFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialValue
                 name="precio_por_caja"
                 value={values.precio_por_caja}
                 onChange={(e) => handleMoneyChange('precio_por_caja', e.target.value, setFieldValue)}
+                onBlur={handleBlur}
                 inputMode="numeric"
                 placeholder="Ej. 220"
                 margin="normal"
                 fullWidth
-                error={Boolean(msg(errors.precio_por_caja))}
-                helperText={msg(errors.precio_por_caja)}
+                error={touched.precio_por_caja && Boolean(msg(errors.precio_por_caja))}
+                helperText={touched.precio_por_caja && msg(errors.precio_por_caja)}
               />
 
               {/* Gasto (OBLIGATORIO, puede ser 0, sin decimales) */}
@@ -312,12 +313,13 @@ const VentaFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialValue
                 name="gasto"
                 value={values.gasto}
                 onChange={(e) => handleMoneyChange('gasto', e.target.value, setFieldValue)}
+                onBlur={handleBlur}
                 inputMode="numeric"
                 placeholder="Ej. 3,500"
                 margin="normal"
                 fullWidth
-                error={Boolean(msg(errors.gasto))}
-                helperText={msg(errors.gasto)}
+                error={touched.gasto && Boolean(msg(errors.gasto))}
+                helperText={touched.gasto && msg(errors.gasto)}
               />
 
               {/* Descripción */}
@@ -326,12 +328,13 @@ const VentaFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialValue
                 name="descripcion"
                 value={values.descripcion}
                 onChange={handleChange}
+                onBlur={handleBlur}
                 margin="normal"
                 fullWidth
                 multiline
                 rows={2}
-                error={Boolean(msg(errors.descripcion))}
-                helperText={msg(errors.descripcion)}
+                error={touched.descripcion && Boolean(msg(errors.descripcion))}
+                helperText={touched.descripcion && msg(errors.descripcion)}
               />
             </DialogContent>
 

--- a/frontend/src/modules/gestion_huerta/components/huerta/HuertaFormModal.tsx
+++ b/frontend/src/modules/gestion_huerta/components/huerta/HuertaFormModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { DialogContent, DialogActions, Button, TextField, CircularProgress } from '@mui/material';
 import Autocomplete from '@mui/material/Autocomplete';
-import { Formik, Form, FormikProps } from 'formik';
+import { Formik, Form, FormikProps, FormikHelpers } from 'formik';
 import * as Yup from 'yup';
 
 import { HuertaCreateData } from '../../types/huertaTypes';
@@ -55,11 +55,11 @@ const HuertaFormModal: React.FC<Props> = ({
     if (!open && formikRef.current) formikRef.current.resetForm();
   }, [open]);
 
-  const submit = async (vals: HuertaCreateData, actions: any) => {
+  const submit = async (vals: HuertaCreateData, actions: FormikHelpers<HuertaCreateData>) => {
     try {
       await onSubmit(vals);
       onClose();
-    } catch (err: any) {
+    } catch (err: unknown) {
       const backend  = err?.data || err?.response?.data || {};
       const beErrors = backend.errors || backend.data?.errors || {};
       const fErrors: Record<string, string> = {};
@@ -68,7 +68,7 @@ const HuertaFormModal: React.FC<Props> = ({
         const msg = beErrors.non_field_errors[0];
         ['nombre', 'ubicacion', 'propietario'].forEach(f => (fErrors[f] = msg));
       }
-      Object.entries(beErrors).forEach(([field, msgs]: any) => {
+      Object.entries(beErrors).forEach(([field, msgs]: [string, unknown]) => {
         if (field !== 'non_field_errors') fErrors[field] = Array.isArray(msgs) ? msgs[0] : String(msgs);
       });
 
@@ -107,8 +107,8 @@ const HuertaFormModal: React.FC<Props> = ({
 
       const lista = await propietarioService.search(input, { signal: abortRef.current.signal });
       return lista.map((p) => ({ id: p.id, label: `${p.nombre} ${p.apellidos} – ${p.telefono}`, value: p.id }));
-    } catch (error: any) {
-      if (error?.name === 'CanceledError') return [];
+    } catch (error: unknown) {
+      if ((error as { name?: string })?.name === 'CanceledError') return [];
       return [];
     } finally {
       setAsyncLoading(false);
@@ -139,7 +139,9 @@ const HuertaFormModal: React.FC<Props> = ({
           if (p) {
             setAsyncOptions([{ id: p.id, label: `${p.nombre} ${p.apellidos} – ${p.telefono}`, value: p.id }]);
           }
-        } catch {}
+        } catch {
+          /* empty */
+        }
       }
     };
     precargar();
@@ -154,7 +156,9 @@ const HuertaFormModal: React.FC<Props> = ({
           if (p) {
             setAsyncOptions([{ id: p.id, label: `${p.nombre} ${p.apellidos} – ${p.telefono}`, value: p.id }]);
           }
-        } catch {}
+        } catch {
+          /* empty */
+        }
       }
     };
     precargarNuevo();
@@ -165,33 +169,59 @@ const HuertaFormModal: React.FC<Props> = ({
       innerRef={formikRef}
       initialValues={initialValues || defaults}
       validationSchema={yupSchema}
-      validateOnChange={false}
-      validateOnBlur={false}
       enableReinitialize
       onSubmit={submit}
     >
-      {({ values, errors, handleChange, setFieldValue, isSubmitting }) => (
+      {({ values, errors, touched, handleChange, handleBlur, setFieldValue, setFieldTouched, isSubmitting }) => (
         <Form>
           <DialogContent dividers className="space-y-4">
-            <TextField fullWidth label="Nombre" name="nombre"
-              value={values.nombre} onChange={handleChange}
-              error={!!errors.nombre} helperText={errors.nombre || ''} />
-            <TextField fullWidth label="Ubicación" name="ubicacion"
-              value={values.ubicacion} onChange={handleChange}
-              error={!!errors.ubicacion} helperText={errors.ubicacion || ''} />
-            <TextField fullWidth label="Variedades (ej. Kent, Ataulfo)" name="variedades"
-              value={values.variedades} onChange={handleChange}
-              error={!!errors.variedades} helperText={errors.variedades || ''} />
-            <TextField fullWidth label="Hectáreas" name="hectareas" type="number"
-              value={values.hectareas} onChange={handleChange}
-              error={!!errors.hectareas} helperText={errors.hectareas || ''} />
+            <TextField
+              fullWidth
+              label="Nombre"
+              name="nombre"
+              value={values.nombre}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              error={touched.nombre && Boolean(errors.nombre)}
+              helperText={touched.nombre && errors.nombre}
+            />
+            <TextField
+              fullWidth
+              label="Ubicación"
+              name="ubicacion"
+              value={values.ubicacion}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              error={touched.ubicacion && Boolean(errors.ubicacion)}
+              helperText={touched.ubicacion && errors.ubicacion}
+            />
+            <TextField
+              fullWidth
+              label="Variedades (ej. Kent, Ataulfo)"
+              name="variedades"
+              value={values.variedades}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              error={touched.variedades && Boolean(errors.variedades)}
+              helperText={touched.variedades && errors.variedades}
+            />
+            <TextField
+              fullWidth
+              label="Hectáreas"
+              name="hectareas"
+              type="number"
+              value={values.hectareas}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              error={touched.hectareas && Boolean(errors.hectareas)}
+              helperText={touched.hectareas && errors.hectareas}
+            />
 
             <Autocomplete
               options={opcionesCombinadas}
               loading={asyncLoading}
               getOptionLabel={(option: OptionType) => option.label}
               isOptionEqualToValue={(option: OptionType, value: OptionType) => option.value === value.value}
-              // sin filtrado local; servidor manda
               filterOptions={(options, state) => state.inputValue.trim() === '' ? [registroNuevo] : options}
               openOnFocus
               value={values.propietario
@@ -207,6 +237,7 @@ const HuertaFormModal: React.FC<Props> = ({
                 } else {
                   setFieldValue('propietario', 0);
                 }
+                setFieldTouched('propietario', true, false);
               }}
               noOptionsText={
                 asyncLoading
@@ -219,10 +250,12 @@ const HuertaFormModal: React.FC<Props> = ({
               renderInput={(params) => (
                 <TextField
                   {...params}
+                  name="propietario"
                   label="Propietario"
                   placeholder="Buscar por nombre, apellido o teléfono..."
-                  error={!!errors.propietario}
-                  helperText={errors.propietario || ''}
+                  onBlur={handleBlur}
+                  error={touched.propietario && Boolean(errors.propietario)}
+                  helperText={touched.propietario && errors.propietario}
                   InputProps={{
                     ...params.InputProps,
                     endAdornment: (

--- a/frontend/src/modules/gestion_huerta/components/propietario/PropietarioFormModal.tsx
+++ b/frontend/src/modules/gestion_huerta/components/propietario/PropietarioFormModal.tsx
@@ -16,8 +16,8 @@ import { PermissionButton } from '../../../../components/common/PermissionButton
 interface Props {
   open: boolean;
   onClose: () => void;
-  onSubmit: (v: PropietarioCreateData) => Promise<any>;
-  onSuccess?: (nuevo: any) => void;
+  onSubmit: (v: PropietarioCreateData) => Promise<unknown>;
+  onSuccess?: (nuevo: unknown) => void;
   initialValues?: PropietarioCreateData;
   isEdit?: boolean;
 }
@@ -68,14 +68,12 @@ export default function PropietarioFormModal({
       <Formik
         initialValues={initialValues || defaults}
         validationSchema={yupSchema}
-        validateOnChange={false}
-        validateOnBlur={false}
         onSubmit={async (vals, { setSubmitting, setErrors }) => {
           try {
             const nuevo = await onSubmit(vals); // ← el thunk ya mostró el toast
             onSuccess?.(nuevo);
             onClose();
-          } catch (error: any) {
+          } catch (error: unknown) {
             const backend = error?.data || error?.response?.data || {};
             const beErrors = backend.errors || backend.data?.errors || {};
             const formikErrors: Record<string, string> = {};
@@ -92,6 +90,7 @@ export default function PropietarioFormModal({
         {({
           values,
           errors,
+          touched,
           handleChange,
           handleBlur,
           isSubmitting,
@@ -100,6 +99,7 @@ export default function PropietarioFormModal({
             <DialogContent dividers className="space-y-4">
               {['nombre', 'apellidos', 'telefono', 'direccion'].map((field) => {
                 const error = errors[field as keyof typeof errors];
+                const isTouched = touched[field as keyof typeof touched];
                 return (
                   <TextField
                     key={field}
@@ -109,8 +109,8 @@ export default function PropietarioFormModal({
                     value={values[field as keyof typeof values]}
                     onChange={handleChange}
                     onBlur={handleBlur}
-                    error={Boolean(error)}
-                    helperText={error || ''}
+                    error={Boolean(isTouched && error)}
+                    helperText={isTouched && error}
                   />
                 );
               })}


### PR DESCRIPTION
## Summary
- unify form validation logic across huerta-related forms
- show field errors only when touched for consistent UX

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/modules/gestion_huerta/components/huerta/HuertaFormModal.tsx src/modules/gestion_huerta/components/huerta_rentada/HuertaRentadaFormModal.tsx src/modules/gestion_huerta/components/propietario/PropietarioFormModal.tsx src/modules/gestion_huerta/components/finanzas/InversionFormModal.tsx src/modules/gestion_huerta/components/finanzas/VentaFormModal.tsx src/modules/gestion_huerta/components/finanzas/CategoriaFormModal.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689e7514129c832c8e8c08ab2da39c78