### PR TITLE
Gate temporadas fetch until huerta selected

### DIFF
--- a/frontend/src/modules/gestion_huerta/hooks/useTemporadas.ts
+++ b/frontend/src/modules/gestion_huerta/hooks/useTemporadas.ts
@@ -21,7 +21,7 @@ import {
   TemporadaCreateData,
 } from '../types/temporadaTypes';
 
-export function useTemporadas() {
+export function useTemporadas({ enabled = true }: { enabled?: boolean } = {}) {
   const dispatch = useAppDispatch();
   const {
     list: temporadas,
@@ -38,16 +38,31 @@ export function useTemporadas() {
   } = useAppSelector((state) => state.temporada);
 
   useEffect(() => {
-    dispatch(fetchTemporadas({ 
-      page, 
-      año: yearFilter || undefined, 
-      huertaId: huertaId || undefined, 
-      huertaRentadaId: huertaRentadaId || undefined,
-      estado: estadoFilter,
-      finalizada: finalizadaFilter ?? undefined,   // <- antes: finalizadaFilter || undefined
-      search: searchFilter || undefined,
-    }));
-  }, [dispatch, page, yearFilter, huertaId, huertaRentadaId, estadoFilter, finalizadaFilter, searchFilter]);
+    if (!enabled) return;
+    if (!huertaId && !huertaRentadaId) return;
+
+    dispatch(
+      fetchTemporadas({
+        page,
+        año: yearFilter || undefined,
+        huertaId: huertaId || undefined,
+        huertaRentadaId: huertaRentadaId || undefined,
+        estado: estadoFilter,
+        finalizada: finalizadaFilter ?? undefined, // <- antes: finalizadaFilter || undefined
+        search: searchFilter || undefined,
+      })
+    );
+  }, [
+    enabled,
+    dispatch,
+    page,
+    yearFilter,
+    huertaId,
+    huertaRentadaId,
+    estadoFilter,
+    finalizadaFilter,
+    searchFilter,
+  ]);
 
 
   const setPageNumber = (n: number) => dispatch(setPage(n));

--- a/frontend/src/modules/gestion_huerta/pages/Temporadas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Temporadas.tsx
@@ -57,6 +57,19 @@ const Temporadas: React.FC = () => {
   const [search] = useSearchParams();
   const huertaId = Number(search.get('huerta_id') || 0) || null;
 
+  const { huertas } = useHuertas();
+  const { huertas: rentadas } = useHuertasRentadas();
+
+  // Detectar huerta seleccionada y sincronizar filtro global
+  const huertaSel = useMemo(() => {
+    if (!huertaId) return null;
+    return (
+      huertas.find((h) => h.id === huertaId) ||
+      rentadas.find((h) => h.id === huertaId) ||
+      null
+    );
+  }, [huertaId, huertas, rentadas]);
+
   const {
     temporadas,
     loading,
@@ -78,20 +91,7 @@ const Temporadas: React.FC = () => {
     finalizeTemporada,
     archiveTemporada,
     restoreTemporada,
-  } = useTemporadas();
-
-  const { huertas } = useHuertas();
-  const { huertas: rentadas } = useHuertasRentadas();
-
-  // Detectar huerta seleccionada y sincronizar filtro global
-  const huertaSel = useMemo(() => {
-    if (!huertaId) return null;
-    return (
-      huertas.find((h) => h.id === huertaId) ||
-      rentadas.find((h) => h.id === huertaId) ||
-      null
-    );
-  }, [huertaId, huertas, rentadas]);
+  } = useTemporadas({ enabled: !!huertaSel });
 
   useEffect(() => {
     if (huertaSel) {


### PR DESCRIPTION
## Summary
- Dispatch temporada fetching only when a huerta id or rentada id is present
- Allow manually enabling the temporadas hook with an `enabled` option
- Wait for huerta resolution in `Temporadas` before triggering fetch

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 214 problems - irregular whitespace, unexpected any, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689e9f8f5420832cbf774c18774c5d86