### PR TITLE
Include huerta type in temporadas URLs and selection

### DIFF
--- a/frontend/src/global/constants/breadcrumbRoutes.ts
+++ b/frontend/src/global/constants/breadcrumbRoutes.ts
@@ -10,10 +10,11 @@ export const breadcrumbRoutes = {
   /** Temporadas de una huerta */
   temporadasList: (
     huertaId: number,
-    huertaName: string
+    huertaName: string,
+    tipo: 'propia' | 'rentada'
   ): Crumb[] => [
     { label: `Huertas – ${huertaName}`, path: `/huertas?huerta_id=${huertaId}` },
-    { label: 'Temporadas',               path: `/temporadas?huerta_id=${huertaId}` },
+    { label: 'Temporadas',               path: `/temporadas?huerta_id=${huertaId}&tipo=${tipo}` },
   ],
 
   /** Cosechas de una temporada */
@@ -21,10 +22,11 @@ export const breadcrumbRoutes = {
     huertaId: number,
     huertaName: string,
     año: number,
-    temporadaId: number    // ← nuevo parámetro
+    temporadaId: number,   // ← nuevo parámetro
+    tipo: 'propia' | 'rentada'
   ): Crumb[] => [
     { label: `Huertas – ${huertaName}`, path: `/huertas?huerta_id=${huertaId}` },
-    { label: `Temporada ${año}`,        path: `/temporadas?huerta_id=${huertaId}` },
+    { label: `Temporada ${año}`,        path: `/temporadas?huerta_id=${huertaId}&tipo=${tipo}` },
     { label: 'Cosechas',                path: `/cosechas?temporada_id=${temporadaId}` }, // ← ahora sí enlaza
   ],
 
@@ -32,10 +34,11 @@ export const breadcrumbRoutes = {
   ventasInversiones: (
     huertaId: number,
     huertaName: string,
-    año: number
+    año: number,
+    tipo: 'propia' | 'rentada'
   ): Crumb[] => [
     { label: `Huertas – ${huertaName}`,     path: `/huertas?huerta_id=${huertaId}` },
-    { label: `Temporada ${año}`,            path: `/temporadas?huerta_id=${huertaId}` },
+    { label: `Temporada ${año}`,            path: `/temporadas?huerta_id=${huertaId}&tipo=${tipo}` },
     { label: 'Ventas & Inversiones',        path: '' /* permanece en la vista actual */ },
   ],
 };

--- a/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
@@ -74,7 +74,13 @@ const Cosechas: React.FC = () => {
         });
         if (t.huerta_id && t.huerta_nombre) {
           dispatch(setBreadcrumbs(
-            breadcrumbRoutes.cosechasList(t.huerta_id, t.huerta_nombre, t.año, t.id)
+            breadcrumbRoutes.cosechasList(
+              t.huerta_id,
+              t.huerta_nombre,
+              t.año,
+              t.id,
+              t.is_rentada ? 'rentada' : 'propia'
+            )
           ));
         } else {
           dispatch(clearBreadcrumbs());

--- a/frontend/src/modules/gestion_huerta/pages/FinanzasPorCosecha.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/FinanzasPorCosecha.tsx
@@ -76,7 +76,13 @@ const FinanzasPorCosecha: React.FC = () => {
 
         const origenId = huertaId ?? huertaRentadaId!;
         dispatch(setBreadcrumbs([
-          ...breadcrumbRoutes.cosechasList(origenId, info.huerta_nombre, info.año, temporadaId),
+          ...breadcrumbRoutes.cosechasList(
+            origenId,
+            info.huerta_nombre,
+            info.año,
+            temporadaId,
+            huertaRentadaId ? 'rentada' : 'propia'
+          ),
           { label: 'Ventas & Inversiones', path: '' }
         ]));
       })

--- a/frontend/src/modules/gestion_huerta/pages/Huertas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Huertas.tsx
@@ -270,7 +270,7 @@ const Huertas: React.FC = () => {
             onDelete={askDelete}
             onArchive={h => handleArchiveOrRestore(h, false)}
             onRestore={h => handleArchiveOrRestore(h, true)}
-            onTemporadas={h => navigate(`/temporadas?huerta_id=${h.id}`)}
+            onTemporadas={h => navigate(`/temporadas?huerta_id=${h.id}&tipo=${isRentada(h) ? 'rentada' : 'propia'}`)}
           />
         </Box>
 

--- a/frontend/src/modules/gestion_huerta/pages/Temporadas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Temporadas.tsx
@@ -56,6 +56,7 @@ const Temporadas: React.FC = () => {
   const navigate = useNavigate(); // 👈 NUEVO
   const [search] = useSearchParams();
   const huertaId = Number(search.get('huerta_id') || 0) || null;
+  const tipo = search.get('tipo') === 'rentada' ? 'rentada' : 'propia';
 
   const {
     temporadas,
@@ -86,16 +87,15 @@ const Temporadas: React.FC = () => {
   // Detectar huerta seleccionada y sincronizar filtro global
   const huertaSel = useMemo(() => {
     if (!huertaId) return null;
-    return (
-      huertas.find((h) => h.id === huertaId) ||
-      rentadas.find((h) => h.id === huertaId) ||
-      null
-    );
-  }, [huertaId, huertas, rentadas]);
+    if (tipo === 'rentada') {
+      return rentadas.find(h => h.id === huertaId) || null;
+    }
+    return huertas.find(h => h.id === huertaId) || null;
+  }, [huertaId, tipo, huertas, rentadas]);
 
   useEffect(() => {
     if (huertaSel) {
-      if ('monto_renta' in huertaSel) {
+      if (tipo === 'rentada') {
         setHuerta(null);
         setHuertaRentada(huertaSel.id);
       } else {
@@ -106,13 +106,13 @@ const Temporadas: React.FC = () => {
       setHuerta(null);
       setHuertaRentada(null);
     }
-  }, [huertaSel, setHuerta, setHuertaRentada]);
+  }, [huertaSel, tipo, setHuerta, setHuertaRentada]);
 
   /* ──────────────────── Breadcrumbs ──────────────────── */
   useEffect(() => {
     if (huertaSel) {
       dispatch(setBreadcrumbs(
-        breadcrumbRoutes.temporadasList(huertaSel.id, huertaSel.nombre)
+        breadcrumbRoutes.temporadasList(huertaSel.id, huertaSel.nombre, tipo)
       ));
     } else {
       dispatch(clearBreadcrumbs());
@@ -121,7 +121,7 @@ const Temporadas: React.FC = () => {
     return () => {
       dispatch(clearBreadcrumbs());
     };
-  }, [dispatch, huertaSel]);
+  }, [dispatch, huertaSel, tipo]);
 
   /* ──────────────────── Estados locales ──────────────────── */
   const [spin, setSpin] = useState(false);


### PR DESCRIPTION
## Summary
- Add `tipo` query parameter to all links targeting `/temporadas`
- Use `tipo` in `Temporadas` page to pick between owned and rented huertas without searching both lists
- Update breadcrumbs and navigation so seasons, harvest and finance pages carry the huerta type

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689e9f906420832c88367e9bf0013afa