### PR TITLE
Gate temporadas fetch until huerta selected and stabilize pagination

### DIFF
--- a/frontend/src/modules/gestion_huerta/hooks/useTemporadas.ts
+++ b/frontend/src/modules/gestion_huerta/hooks/useTemporadas.ts
@@ -1,6 +1,6 @@
 // src/modules/gestion_huerta/hooks/useTemporadas.ts
 
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useAppDispatch, useAppSelector } from '../../../global/store/store';
 import {
   fetchTemporadas,
@@ -21,7 +21,7 @@ import {
   TemporadaCreateData,
 } from '../types/temporadaTypes';
 
-export function useTemporadas() {
+export function useTemporadas({ enabled = true }: { enabled?: boolean } = {}) {
   const dispatch = useAppDispatch();
   const {
     list: temporadas,
@@ -38,25 +38,62 @@ export function useTemporadas() {
   } = useAppSelector((state) => state.temporada);
 
   useEffect(() => {
-    dispatch(fetchTemporadas({ 
-      page, 
-      año: yearFilter || undefined, 
-      huertaId: huertaId || undefined, 
-      huertaRentadaId: huertaRentadaId || undefined,
-      estado: estadoFilter,
-      finalizada: finalizadaFilter ?? undefined,   // <- antes: finalizadaFilter || undefined
-      search: searchFilter || undefined,
-    }));
-  }, [dispatch, page, yearFilter, huertaId, huertaRentadaId, estadoFilter, finalizadaFilter, searchFilter]);
+    if (!enabled) return;
+    if (!huertaId && !huertaRentadaId) return;
+
+    dispatch(
+      fetchTemporadas({
+        page,
+        año: yearFilter || undefined,
+        huertaId: huertaId || undefined,
+        huertaRentadaId: huertaRentadaId || undefined,
+        estado: estadoFilter,
+        finalizada: finalizadaFilter ?? undefined, // <- antes: finalizadaFilter || undefined
+        search: searchFilter || undefined,
+      })
+    );
+  }, [
+    enabled,
+    dispatch,
+    page,
+    yearFilter,
+    huertaId,
+    huertaRentadaId,
+    estadoFilter,
+    finalizadaFilter,
+    searchFilter,
+  ]);
 
 
-  const setPageNumber = (n: number) => dispatch(setPage(n));
-  const setYear = (y: number | null) => dispatch(setYearFilter(y));
-  const setHuerta = (id: number | null) => dispatch(setHuertaId(id));
-  const setHuertaRentada = (id: number | null) => dispatch(setHuertaRentadaId(id));
-  const setEstado = (estado: 'activas' | 'archivadas' | 'todas') => dispatch(setEstadoFilter(estado));
-  const setFinalizada = (finalizada: boolean | null) => dispatch(setFinalizadaFilter(finalizada));
-  const setSearch = (search: string) => dispatch(setSearchFilter(search));
+  const setPageNumber = useCallback(
+    (n: number) => dispatch(setPage(n)),
+    [dispatch]
+  );
+  const setYear = useCallback(
+    (y: number | null) => dispatch(setYearFilter(y)),
+    [dispatch]
+  );
+  const setHuerta = useCallback(
+    (id: number | null) => dispatch(setHuertaId(id)),
+    [dispatch]
+  );
+  const setHuertaRentada = useCallback(
+    (id: number | null) => dispatch(setHuertaRentadaId(id)),
+    [dispatch]
+  );
+  const setEstado = useCallback(
+    (estado: 'activas' | 'archivadas' | 'todas') =>
+      dispatch(setEstadoFilter(estado)),
+    [dispatch]
+  );
+  const setFinalizada = useCallback(
+    (finalizada: boolean | null) => dispatch(setFinalizadaFilter(finalizada)),
+    [dispatch]
+  );
+  const setSearch = useCallback(
+    (search: string) => dispatch(setSearchFilter(search)),
+    [dispatch]
+  );
 
   // Helper para refrescar con filtros actuales
   const refreshWithCurrentFilters = () => {

--- a/frontend/src/modules/gestion_huerta/pages/Temporadas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Temporadas.tsx
@@ -57,6 +57,19 @@ const Temporadas: React.FC = () => {
   const [search] = useSearchParams();
   const huertaId = Number(search.get('huerta_id') || 0) || null;
 
+  const { huertas } = useHuertas();
+  const { huertas: rentadas } = useHuertasRentadas();
+
+  // Detectar huerta seleccionada y sincronizar filtro global
+  const huertaSel = useMemo(() => {
+    if (!huertaId) return null;
+    return (
+      huertas.find((h) => h.id === huertaId) ||
+      rentadas.find((h) => h.id === huertaId) ||
+      null
+    );
+  }, [huertaId, huertas, rentadas]);
+
   const {
     temporadas,
     loading,
@@ -71,42 +84,37 @@ const Temporadas: React.FC = () => {
     setEstado,
     setFinalizada,
     setSearch,
+    huertaId: selHuertaId,
     setHuerta,
+    huertaRentadaId: selHuertaRentadaId,
     setHuertaRentada,
     addTemporada,
     removeTemporada,
     finalizeTemporada,
     archiveTemporada,
     restoreTemporada,
-  } = useTemporadas();
-
-  const { huertas } = useHuertas();
-  const { huertas: rentadas } = useHuertasRentadas();
-
-  // Detectar huerta seleccionada y sincronizar filtro global
-  const huertaSel = useMemo(() => {
-    if (!huertaId) return null;
-    return (
-      huertas.find((h) => h.id === huertaId) ||
-      rentadas.find((h) => h.id === huertaId) ||
-      null
-    );
-  }, [huertaId, huertas, rentadas]);
+  } = useTemporadas({ enabled: !!huertaSel });
 
   useEffect(() => {
     if (huertaSel) {
       if ('monto_renta' in huertaSel) {
-        setHuerta(null);
-        setHuertaRentada(huertaSel.id);
+        if (selHuertaRentadaId !== huertaSel.id) setHuertaRentada(huertaSel.id);
+        if (selHuertaId !== null) setHuerta(null);
       } else {
-        setHuerta(huertaSel.id);
-        setHuertaRentada(null);
+        if (selHuertaId !== huertaSel.id) setHuerta(huertaSel.id);
+        if (selHuertaRentadaId !== null) setHuertaRentada(null);
       }
     } else {
-      setHuerta(null);
-      setHuertaRentada(null);
+      if (selHuertaId !== null) setHuerta(null);
+      if (selHuertaRentadaId !== null) setHuertaRentada(null);
     }
-  }, [huertaSel, setHuerta, setHuertaRentada]);
+  }, [
+    huertaSel,
+    selHuertaId,
+    selHuertaRentadaId,
+    setHuerta,
+    setHuertaRentada,
+  ]);
 
   /* ──────────────────── Breadcrumbs ──────────────────── */
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Dispatch temporada fetching only when a huerta id or rentada id is present
- Allow manually enabling the temporadas hook with an `enabled` option
- Wait for huerta resolution in `Temporadas` before triggering fetch
- Memoize hook setters and conditionally update huerta filters to prevent pagination flicker

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 214 problems - unexpected any, irregular whitespace, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689e9f8f5420832cbf774c18774c5d86