### PR TITLE
Prevent multiple active harvests per season

### DIFF
--- a/backend/gestion_huerta/serializers.py
+++ b/backend/gestion_huerta/serializers.py
@@ -325,12 +325,27 @@ class CosechaSerializer(serializers.ModelSerializer):
         fi         = data.get('fecha_inicio') or (instance.fecha_inicio if instance else None)
         ff         = data.get('fecha_fin')    or (instance.fecha_fin    if instance else None)
         nombre_in  = data.get('nombre', None)
+        finalizada = data.get('finalizada') if 'finalizada' in data else (
+            instance.finalizada if instance else False
+        )
 
         if not temporada:
             raise ValidationError("La cosecha debe pertenecer a una temporada.")
 
         if fi and ff and ff < fi:
             raise ValidationError("La fecha de fin no puede ser anterior a la fecha de inicio.")
+
+        # Impedir múltiples cosechas activas en la misma temporada
+        if not finalizada and temporada:
+            qs = Cosecha.objects.filter(
+                temporada=temporada,
+                finalizada=False,
+                is_active=True,
+            )
+            if instance:
+                qs = qs.exclude(pk=instance.pk)
+            if qs.exists():
+                raise ValidationError("Ya existe una cosecha activa en esta temporada.")
 
         # Reglas de creación
         if instance is None:

--- a/backend/gestion_huerta/test/test_cosecha_unique_active.py
+++ b/backend/gestion_huerta/test/test_cosecha_unique_active.py
@@ -1,0 +1,54 @@
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from gestion_huerta.models import Propietario, Huerta, Temporada, Cosecha
+
+
+class CosechaActiveConstraintTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            telefono='9999999999',
+            password='pass',
+            nombre='Admin',
+            apellido='User',
+            role='admin',
+        )
+        self.client.force_authenticate(self.user)
+
+        self.propietario = Propietario.objects.create(
+            nombre='Juan',
+            apellidos='Pérez',
+            telefono='1234567890',
+            direccion='Calle 1',
+        )
+        self.huerta = Huerta.objects.create(
+            nombre='Huerta 1',
+            ubicacion='Ubic',
+            variedades='Var',
+            hectareas=1.0,
+            propietario=self.propietario,
+        )
+        self.temporada = Temporada.objects.create(año=2024, huerta=self.huerta)
+        self.cosecha = Cosecha.objects.create(nombre='C1', temporada=self.temporada, huerta=self.huerta)
+
+    def test_prevent_second_active_cosecha(self):
+        url = reverse('huerta:cosecha-list')
+        payload = {
+            'temporada': self.temporada.id,
+            'nombre': 'Cosecha 2',
+        }
+        response = self.client.post(url, payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_allow_creation_after_finalized(self):
+        self.cosecha.finalizar()
+        url = reverse('huerta:cosecha-list')
+        payload = {
+            'temporada': self.temporada.id,
+            'nombre': 'Cosecha 2',
+        }
+        response = self.client.post(url, payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/backend/gestion_huerta/views/cosechas_views.py
+++ b/backend/gestion_huerta/views/cosechas_views.py
@@ -48,6 +48,8 @@ def _map_cosecha_validation_errors(errors: dict) -> tuple[str, dict]:
             return "cosecha_limite_temporada", {"errors": errors}
         if txt == "Ya existe una cosecha con ese nombre en esta temporada.":
             return "cosecha_duplicada", {"errors": errors}
+        if txt == "Ya existe una cosecha activa en esta temporada.":
+            return "cosecha_activa_existente", {"errors": errors}
         if txt == "No puedes cambiar la temporada de una cosecha existente.":
             return "cosecha_cambiar_temporada_prohibido", {"errors": errors}
         if txt == "El nombre de la cosecha debe tener al menos 3 caracteres.":


### PR DESCRIPTION
## Summary
- ensure a temporada cannot have more than one active, non-finalized cosecha
- surface a specific notification key when this validation is triggered
- add tests for allowing new cosechas only after finalizing previous ones

## Testing
- `python backend/manage.py test backend/gestion_huerta/test -v 2 --settings=agroproductores_risol.test_settings`

------
https://chatgpt.com/codex/tasks/task_e_689efb9987a4832c8c0e90b8031df235