### PR TITLE
Fetch huerta data directly by ID

### DIFF
--- a/frontend/src/modules/gestion_huerta/services/huertaRentadaService.ts
+++ b/frontend/src/modules/gestion_huerta/services/huertaRentadaService.ts
@@ -39,6 +39,15 @@ export const huertaRentadaService = {
     return { huertas_rentadas: list, meta: raw.meta };
   },
 
+  async retrieve(id: number, config: { signal?: AbortSignal } = {}): Promise<HuertaRentada> {
+    const { data } = await apiClient.get<{
+      success: boolean;
+      message_key: string;
+      data: ItemWrapper;
+    }>(`/huerta/huertas-rentadas/${id}/`, { signal: config.signal });
+    return data.data.huerta_rentada;
+  },
+
   async create(payload: HuertaRentadaCreateData) {
     const { data } = await apiClient.post<{
       success: boolean;

--- a/frontend/src/modules/gestion_huerta/services/huertaService.ts
+++ b/frontend/src/modules/gestion_huerta/services/huertaService.ts
@@ -41,6 +41,15 @@ export const huertaService = {
     return { huertas: list, meta: raw.meta };
   },
 
+  async retrieve(id: number, config: { signal?: AbortSignal } = {}): Promise<Huerta> {
+    const { data } = await apiClient.get<{
+      success: boolean;
+      message_key: string;
+      data: ItemWrapper;
+    }>(`/huerta/huertas/${id}/`, { signal: config.signal });
+    return data.data.huerta;
+  },
+
   async create(payload: HuertaCreateData) {
     const { data } = await apiClient.post<{
       success: boolean;


### PR DESCRIPTION
## Summary
- Add retrieve methods to huerta and huerta rentada services
- Load selected huerta in Temporadas page via service calls and handle loading/error states

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no project lint configuration passes; see log)*

------
https://chatgpt.com/codex/tasks/task_e_689feae5b49c832ca0bd192daaa7bfba