### PR TITLE
fix: avoid redundant huerta state updates

### DIFF
--- a/frontend/src/modules/gestion_huerta/pages/Huertas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Huertas.tsx
@@ -50,8 +50,10 @@ const Huertas: React.FC = () => {
 
   const [tab, setTab] = useState<VistaTab>('activos');
   useEffect(() => {
-    hComb.setEstado(tab);
-  }, [tab]);
+    if (hComb.estado !== tab) {
+      hComb.setEstado(tab);
+    }
+  }, [tab, hComb.estado]);
 
   // 🔧 Mueve los estados que usas en handlers por ENCIMA de las funciones:
   const [modalOpen, setModalOpen] = useState(false);


### PR DESCRIPTION
## Summary
- avoid re-dispatching huerta tab state when unchanged to keep active view stable

## Testing
- `npm run lint` *(fails: 227 problems)*
- `npm run build` *(fails: Property 'data' does not exist on type '{}')*


------
https://chatgpt.com/codex/tasks/task_e_689feae928a8832ca660df9b55382903