### PR TITLE
refactor: remove huerta hooks from Temporadas

### DIFF
--- a/frontend/src/modules/gestion_huerta/components/temporada/TemporadaFormModal.tsx
+++ b/frontend/src/modules/gestion_huerta/components/temporada/TemporadaFormModal.tsx
@@ -10,8 +10,6 @@ import {
 } from '@mui/material';
 import { Formik, Form, FormikHelpers } from 'formik';
 import * as Yup from 'yup';
-import { Huerta } from '../../types/huertaTypes';
-import { HuertaRentada } from '../../types/huertaRentadaTypes';
 import { Temporada, TemporadaCreateData } from '../../types/temporadaTypes';
 import { PermissionButton } from '../../../../components/common/PermissionButton';
 
@@ -36,8 +34,6 @@ interface TemporadaFormModalProps {
   open: boolean;
   onClose: () => void;
   onSubmit?: (values: TemporadaCreateData) => Promise<void>;
-  huertas: Huerta[];
-  huertasRentadas: HuertaRentada[];
   initialValues?: Temporada;
   readOnly?: boolean; // ← NUEVO
 }
@@ -48,8 +44,6 @@ const TemporadaFormModal: React.FC<TemporadaFormModalProps> = ({
   open,
   onClose,
   onSubmit,
-  huertas,
-  huertasRentadas,
   initialValues,
   readOnly = false,
 }) => {
@@ -85,11 +79,7 @@ const TemporadaFormModal: React.FC<TemporadaFormModalProps> = ({
     return errors;
   };
 
-  const huertaNombre =
-    initialValues?.huerta_nombre ||
-    huertas.find((h) => h.id === initialValues?.huerta)?.nombre ||
-    huertasRentadas.find((h) => h.id === initialValues?.huerta_rentada)?.nombre ||
-    '';
+  const huertaNombre = initialValues?.huerta_nombre || '';
 
   const handleSubmit = async (
     values: TemporadaCreateData,

--- a/frontend/src/modules/gestion_huerta/pages/Temporadas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Temporadas.tsx
@@ -22,8 +22,6 @@ import TemporadaTable from '../components/temporada/TemporadaTable';
 import TemporadaToolbar from '../components/temporada/TemporadaToolbar';
 import TemporadaFormModal from '../components/temporada/TemporadaFormModal';
 import { useTemporadas } from '../hooks/useTemporadas';
-import { useHuertas } from '../hooks/useHuertas';
-import { useHuertasRentadas } from '../hooks/useHuertaRentada';
 import { TemporadaCreateData, Temporada } from '../types/temporadaTypes';
 import { Huerta } from '../types/huertaTypes';
 import { HuertaRentada } from '../types/huertaRentadaTypes';
@@ -61,8 +59,6 @@ const Temporadas: React.FC = () => {
   const [search] = useSearchParams();
   const huertaId = Number(search.get('huerta_id') || 0) || null;
 
-  const { huertas } = useHuertas();
-  const { huertas: rentadas } = useHuertasRentadas();
 
   const [huertaSel, setHuertaSel] = useState<Huerta | HuertaRentada | null>(null);
   const [huertaLoading, setHuertaLoading] = useState(false);
@@ -394,8 +390,6 @@ const Temporadas: React.FC = () => {
             setConsultOpen(false);
           }}
           initialValues={consultTarget || undefined}
-          huertas={huertas}
-          huertasRentadas={rentadas}
           readOnly
         />
 


### PR DESCRIPTION
## Summary
- remove unused huerta hooks from Temporadas page
- simplify TemporadaFormModal to rely on temporada data directly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ff9bebb90832c9f60c6a07c3fc075