### PR TITLE
Handle deletion errors in Inversion and Venta

### DIFF
--- a/frontend/src/modules/gestion_huerta/pages/Inversion.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Inversion.tsx
@@ -11,6 +11,7 @@ import InversionFormModal from '../components/finanzas/InversionFormModal';
 import { categoriaInversionService } from '../services/categoriaInversionService';
 import { temporadaService } from '../services/temporadaService';
 import { cosechaService } from '../services/cosechaService';
+import { handleBackendNotification } from '../../../global/utils/NotificationEngine';
 
 const PAGE_SIZE = 10;
 
@@ -165,8 +166,13 @@ const Inversion: React.FC = () => {
   const [delId, setDelId] = useState<number | null>(null);
   const confirmDelete = async () => {
     if (delId == null) return;
-    await removeInversion(delId);
-    setDelId(null);
+    try {
+      await removeInversion(delId);
+    } catch (e: any) {
+      handleBackendNotification(e?.response?.data?.notification || e);
+    } finally {
+      setDelId(null);
+    }
   };
 
   return (

--- a/frontend/src/modules/gestion_huerta/pages/Venta.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Venta.tsx
@@ -10,6 +10,7 @@ import VentaTable   from '../components/finanzas/VentaTable';
 import VentaFormModal from '../components/finanzas/VentaFormModal';
 import { temporadaService } from '../services/temporadaService';
 import { cosechaService } from '../services/cosechaService';
+import { handleBackendNotification } from '../../../global/utils/NotificationEngine';
 
 const PAGE_SIZE = 10;
 
@@ -117,8 +118,13 @@ const Venta: React.FC = () => {
   const [delId, setDelId] = useState<number | null>(null);
   const confirmDelete = async () => {
     if (delId == null) return;
-    await removeVenta(delId);
-    setDelId(null);
+    try {
+      await removeVenta(delId);
+    } catch (e: any) {
+      handleBackendNotification(e?.response?.data?.notification || e);
+    } finally {
+      setDelId(null);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- catch `removeInversion` errors and notify users via `handleBackendNotification`
- catch `removeVenta` errors and notify users via `handleBackendNotification`

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 229 problems)


------
https://chatgpt.com/codex/tasks/task_e_689ff9c52c58832c8ca189a5f5a13265