### PR TITLE
Wrap temporada and cosecha retrieve responses

### DIFF
--- a/backend/gestion_huerta/views/cosechas_views.py
+++ b/backend/gestion_huerta/views/cosechas_views.py
@@ -12,6 +12,7 @@ from gestion_huerta.utils.audit import ViewSetAuditMixin
 from agroproductores_risol.utils.pagination import GenericPagination
 from gestion_huerta.views.huerta_views import NotificationMixin
 from gestion_huerta.permissions import HasHuertaModulePermission, HuertaGranularPermission
+from gestion_huerta.utils.notification_handler import NotificationHandler
 
 
 def _map_cosecha_validation_errors(errors: dict) -> tuple[str, dict]:
@@ -127,6 +128,16 @@ class CosechaViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.ModelViewSet
                 "cosechas": serializer.data,
                 "meta": {"count": len(serializer.data), "next": None, "previous": None}
             }
+        )
+
+    # ------------------------------ RETRIEVE ------------------------------
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        return NotificationHandler.generate_response(
+            message_key="data_processed_success",
+            data={"cosecha": serializer.data},
+            status_code=status.HTTP_200_OK,
         )
 
     # ------------------------------ CREATE ------------------------------

--- a/backend/gestion_huerta/views/temporadas_views.py
+++ b/backend/gestion_huerta/views/temporadas_views.py
@@ -153,6 +153,16 @@ class TemporadaViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.ModelViewS
             status_code=status.HTTP_200_OK
         )
 
+    # --------------------------------- RETRIEVE ---------------------------------
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        ser = self.get_serializer(instance)
+        return NotificationHandler.generate_response(
+            message_key="data_processed_success",
+            data={"temporada": ser.data},
+            status_code=status.HTTP_200_OK,
+        )
+
     # --------------------------------- CREATE ---------------------------------
     def create(self, request, *args, **kwargs):
         data = request.data.copy()

--- a/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
@@ -61,8 +61,7 @@ const Cosechas: React.FC = () => {
     (async () => {
       try {
         setTempLoading(true);
-        const resp = await temporadaService.getById(temporadaId);
-        const t = resp.data.temporada;
+        const { data: { temporada: t } } = await temporadaService.getById(temporadaId);
         setTempInfo({
           id: t.id,
           año: t.año,

--- a/frontend/src/modules/gestion_huerta/pages/FinanzasPorCosecha.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/FinanzasPorCosecha.tsx
@@ -59,8 +59,8 @@ const FinanzasPorCosecha: React.FC = () => {
     setLoadingTemp(true);
 
     temporadaService.getById(temporadaId)
-      .then(res => {
-        const t = res.data.temporada;
+      .then(({ data }) => {
+        const t = data.temporada;
         const huertaId        = t.huerta ?? null;
         const huertaRentadaId = t.huerta_rentada ?? null;
 

--- a/frontend/src/modules/gestion_huerta/pages/Inversion.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Inversion.tsx
@@ -60,18 +60,21 @@ const Inversion: React.FC = () => {
     let alive = true;
     (async () => {
       try {
-        const [tRes, cRes] = await Promise.all([
+        const [
+          { data: { temporada } },
+          { data: { cosecha } },
+        ] = await Promise.all([
           temporadaService.getById(temporadaId),
           cosechaService.getById(cosechaId),
         ]);
         if (!alive) return;
         setTempState({
-          is_active: tRes.data.temporada.is_active,
-          finalizada: tRes.data.temporada.finalizada,
+          is_active: temporada.is_active,
+          finalizada: temporada.finalizada,
         });
         setCosechaState({
-          is_active: cRes.data.cosecha.is_active,
-          finalizada: cRes.data.cosecha.finalizada,
+          is_active: cosecha.is_active,
+          finalizada: cosecha.finalizada,
         });
       } catch {
         if (!alive) return;

--- a/frontend/src/modules/gestion_huerta/pages/Venta.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Venta.tsx
@@ -55,18 +55,21 @@ const Venta: React.FC = () => {
     let alive = true;
     (async () => {
       try {
-        const [tRes, cRes] = await Promise.all([
+        const [
+          { data: { temporada } },
+          { data: { cosecha } },
+        ] = await Promise.all([
           temporadaService.getById(temporadaId),
           cosechaService.getById(cosechaId),
         ]);
         if (!alive) return;
         setTempState({
-          is_active: tRes.data.temporada.is_active,
-          finalizada: tRes.data.temporada.finalizada,
+          is_active: temporada.is_active,
+          finalizada: temporada.finalizada,
         });
         setCosechaState({
-          is_active: cRes.data.cosecha.is_active,
-          finalizada: cRes.data.cosecha.finalizada,
+          is_active: cosecha.is_active,
+          finalizada: cosecha.finalizada,
         });
       } catch {
         if (!alive) return;

--- a/frontend/src/modules/gestion_huerta/services/cosechaService.ts
+++ b/frontend/src/modules/gestion_huerta/services/cosechaService.ts
@@ -120,10 +120,12 @@ export const cosechaService = {
     return response.data;
   },
 
-  // GET BY ID (normalizado)
-  getById(id: number): Promise<{ data: { cosecha: Cosecha } }> {
-    return apiClient
-      .get<Cosecha>(`/huerta/cosechas/${id}/`)
-      .then((res) => ({ data: { cosecha: res.data } }));
+  async getById(id: number) {
+    const response = await apiClient.get<{
+      success: boolean;
+      notification: { key: string; message: string; type: 'success' | 'error' | 'warning' | 'info' };
+      data: { cosecha: Cosecha };
+    }>(`/huerta/cosechas/${id}/`);
+    return response.data;
   },
 };

--- a/frontend/src/modules/gestion_huerta/services/temporadaService.ts
+++ b/frontend/src/modules/gestion_huerta/services/temporadaService.ts
@@ -90,12 +90,12 @@ async list(
     return response.data;
   },
 
-  // 👇 TIPADO EXPLÍCITO DEL RETORNO
-  getById(id: number): Promise<{ data: { temporada: Temporada } }> {
-    return apiClient
-      .get<Temporada>(`/huerta/temporadas/${id}/`)
-      .then((res) => ({
-        data: { temporada: res.data },
-      }));
+  async getById(id: number) {
+    const response = await apiClient.get<{
+      success: boolean;
+      notification: { key: string; message: string; type: 'success'|'error'|'warning'|'info' };
+      data: { temporada: Temporada };
+    }>(`/huerta/temporadas/${id}/`);
+    return response.data;
   },
 };


### PR DESCRIPTION
## Summary
- ensure temporada and cosecha retrieve endpoints respond using NotificationHandler
- expose wrapped data in temporadaService and cosechaService
- update UI pages to consume wrapped temporada/cosecha payloads

## Testing
- `python -m pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ff9c6cbd0832c9a3bec0d89927261