### PR TITLE
Fix huerta navigation and limit notifications

### DIFF
--- a/frontend/src/global/constants/breadcrumbRoutes.ts
+++ b/frontend/src/global/constants/breadcrumbRoutes.ts
@@ -10,10 +10,11 @@ export const breadcrumbRoutes = {
   /** Temporadas de una huerta */
   temporadasList: (
     huertaId: number,
-    huertaName: string
+    huertaName: string,
+    tipo: 'propia' | 'rentada'
   ): Crumb[] => [
-    { label: `Huertas – ${huertaName}`, path: `/huertas?huerta_id=${huertaId}` },
-    { label: 'Temporadas',               path: `/temporadas?huerta_id=${huertaId}` },
+    { label: `Huertas – ${huertaName}`, path: `/huertas` },
+    { label: 'Temporadas',               path: `/temporadas?huerta_id=${huertaId}&tipo=${tipo}` },
   ],
 
   /** Cosechas de una temporada */
@@ -21,21 +22,23 @@ export const breadcrumbRoutes = {
     huertaId: number,
     huertaName: string,
     año: number,
-    temporadaId: number    // ← nuevo parámetro
+    temporadaId: number,
+    tipo: 'propia' | 'rentada'
   ): Crumb[] => [
-    { label: `Huertas – ${huertaName}`, path: `/huertas?huerta_id=${huertaId}` },
-    { label: `Temporada ${año}`,        path: `/temporadas?huerta_id=${huertaId}` },
-    { label: 'Cosechas',                path: `/cosechas?temporada_id=${temporadaId}` }, // ← ahora sí enlaza
+    { label: `Huertas – ${huertaName}`, path: `/huertas` },
+    { label: `Temporada ${año}`,        path: `/temporadas?huerta_id=${huertaId}&tipo=${tipo}` },
+    { label: 'Cosechas',                path: `/cosechas?temporada_id=${temporadaId}` },
   ],
 
   /** Ventas & Inversiones */
   ventasInversiones: (
     huertaId: number,
     huertaName: string,
-    año: number
+    año: number,
+    tipo: 'propia' | 'rentada'
   ): Crumb[] => [
-    { label: `Huertas – ${huertaName}`,     path: `/huertas?huerta_id=${huertaId}` },
-    { label: `Temporada ${año}`,            path: `/temporadas?huerta_id=${huertaId}` },
+    { label: `Huertas – ${huertaName}`,     path: `/huertas` },
+    { label: `Temporada ${año}`,            path: `/temporadas?huerta_id=${huertaId}&tipo=${tipo}` },
     { label: 'Ventas & Inversiones',        path: '' /* permanece en la vista actual */ },
   ],
 };

--- a/frontend/src/global/store/cosechasSlice.ts
+++ b/frontend/src/global/store/cosechasSlice.ts
@@ -40,7 +40,7 @@ export const fetchCosechas = createAsyncThunk<
       return { cosechas: res.data.cosechas, meta: res.data.meta, page };
     } catch (err: any) {
       const payload = err?.response?.data || { message: 'Error al cargar cosechas' };
-      handleBackendNotification(payload.notification || payload);
+      handleBackendNotification(payload);
       return rejectWithValue(payload);
     }
   }
@@ -56,7 +56,7 @@ export const createCosecha = createAsyncThunk<Cosecha, CosechaCreateData, { reje
       return res.data.cosecha;
     } catch (err: any) {
       const payload = err?.response?.data || { message: 'Error al crear cosecha' };
-      handleBackendNotification(payload.notification || payload);
+      handleBackendNotification(payload);
       return rejectWithValue(payload);
     }
   }
@@ -76,7 +76,7 @@ export const updateCosecha = createAsyncThunk<
       return res.data.cosecha;
     } catch (err: any) {
       const payload = err?.response?.data || { message: 'Error al actualizar cosecha' };
-      handleBackendNotification(payload.notification || payload);
+      handleBackendNotification(payload);
       return rejectWithValue(payload);
     }
   }
@@ -92,7 +92,7 @@ export const deleteCosecha = createAsyncThunk<number, number, { rejectValue: Rec
       return id;
     } catch (err: any) {
       const payload = err?.response?.data || { message: 'Error al eliminar cosecha' };
-      handleBackendNotification(payload.notification || payload);
+      handleBackendNotification(payload);
       return rejectWithValue(payload);
     }
   }
@@ -108,7 +108,7 @@ export const archivarCosecha = createAsyncThunk<Cosecha, number, { rejectValue: 
       return res.data.cosecha;
     } catch (err: any) {
       const payload = err?.response?.data || { message: 'Error al archivar cosecha' };
-      handleBackendNotification(payload.notification || payload);
+      handleBackendNotification(payload);
       return rejectWithValue(payload);
     }
   }
@@ -124,7 +124,7 @@ export const restaurarCosecha = createAsyncThunk<Cosecha, number, { rejectValue:
       return res.data.cosecha;
     } catch (err: any) {
       const payload = err?.response?.data || { message: 'Error al restaurar cosecha' };
-      handleBackendNotification(payload.notification || payload);
+      handleBackendNotification(payload);
       return rejectWithValue(payload);
     }
   }
@@ -140,7 +140,7 @@ export const toggleFinalizadaCosecha = createAsyncThunk<Cosecha, number, { rejec
       return res.data.cosecha;
     } catch (err: any) {
       const payload = err?.response?.data || { message: 'Error al cambiar estado de cosecha' };
-      handleBackendNotification(payload.notification || payload);
+      handleBackendNotification(payload);
       return rejectWithValue(payload);
     }
   }

--- a/frontend/src/global/store/temporadaSlice.ts
+++ b/frontend/src/global/store/temporadaSlice.ts
@@ -68,7 +68,7 @@ export const fetchTemporadas = createAsyncThunk<
       };
     } catch (err: any) {
       const errorPayload = err.response?.data || { message: 'Error al cargar temporadas' };
-      handleBackendNotification(errorPayload.notification || errorPayload);
+      handleBackendNotification(errorPayload);
       return rejectWithValue(errorPayload);
     }
   }
@@ -87,7 +87,7 @@ export const createTemporada = createAsyncThunk<
       return res.data.temporada;
     } catch (err: any) {
       const errorPayload = err.response?.data || { message: 'Error al crear temporada' };
-      handleBackendNotification(errorPayload.notification || errorPayload);
+      handleBackendNotification(errorPayload);
       return rejectWithValue(errorPayload);
     }
   }
@@ -106,7 +106,7 @@ export const deleteTemporada = createAsyncThunk<
       return id;
     } catch (err: any) {
       const errorPayload = err.response?.data || { message: 'Error al eliminar temporada' };
-      handleBackendNotification(errorPayload.notification || errorPayload);
+      handleBackendNotification(errorPayload);
       return rejectWithValue(errorPayload);
     }
   }
@@ -125,7 +125,7 @@ export const finalizarTemporada = createAsyncThunk<
       return res.data.temporada;
     } catch (err: any) {
       const errorPayload = err.response?.data || { message: 'Error al finalizar temporada' };
-      handleBackendNotification(errorPayload.notification || errorPayload);
+      handleBackendNotification(errorPayload);
       return rejectWithValue(errorPayload);
     }
   }
@@ -144,7 +144,7 @@ export const archivarTemporada = createAsyncThunk<
       return res.data.temporada;
     } catch (err: any) {
       const errorPayload = err.response?.data || { message: 'Error al archivar temporada' };
-      handleBackendNotification(errorPayload.notification || errorPayload);
+      handleBackendNotification(errorPayload);
       return rejectWithValue(errorPayload);
     }
   }
@@ -163,7 +163,7 @@ export const restaurarTemporada = createAsyncThunk<
       return res.data.temporada;
     } catch (err: any) {
       const errorPayload = err.response?.data || { message: 'Error al restaurar temporada' };
-      handleBackendNotification(errorPayload.notification || errorPayload);
+      handleBackendNotification(errorPayload);
       return rejectWithValue(errorPayload);
     }
   }

--- a/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
@@ -74,7 +74,13 @@ const Cosechas: React.FC = () => {
         });
         if (t.huerta_id && t.huerta_nombre) {
           dispatch(setBreadcrumbs(
-            breadcrumbRoutes.cosechasList(t.huerta_id, t.huerta_nombre, t.año, t.id)
+            breadcrumbRoutes.cosechasList(
+              t.huerta_id,
+              t.huerta_nombre,
+              t.año,
+              t.id,
+              t.is_rentada ? 'rentada' : 'propia'
+            )
           ));
         } else {
           dispatch(clearBreadcrumbs());
@@ -92,6 +98,10 @@ const Cosechas: React.FC = () => {
   useEffect(() => {
     setTemporadaId(temporadaId);
   }, [temporadaId]);
+
+  useEffect(() => {
+    return () => { setTemporadaId(null); };
+  }, [setTemporadaId]);
 
   // Lógica de creación
   const totalCosechas = meta.count;
@@ -141,7 +151,7 @@ const Cosechas: React.FC = () => {
     try {
       await addCosecha({ temporada: temporadaId, nombre });
     } catch (e: any) {
-      handleBackendNotification(e?.response?.data?.notification || e);
+      handleBackendNotification(e?.response?.data || e);
     }
   };
 
@@ -156,7 +166,7 @@ const Cosechas: React.FC = () => {
       setEditOpen(false);
       setEditTarget(null);
     } catch (e: any) {
-      handleBackendNotification(e?.response?.data?.notification || e);
+      handleBackendNotification(e?.response?.data || e);
     }
   };
 
@@ -167,7 +177,7 @@ const Cosechas: React.FC = () => {
     try {
       await removeCosecha(delId);
     } catch (e: any) {
-      handleBackendNotification(e?.response?.data?.notification || e);
+      handleBackendNotification(e?.response?.data || e);
     } finally {
       setDelId(null);
     }
@@ -176,15 +186,15 @@ const Cosechas: React.FC = () => {
   // Acciones fila
   const handleArchive = async (c: Cosecha) => {
     try { await archiveCosecha(c.id); }
-    catch (e: any) { handleBackendNotification(e?.response?.data?.notification || e); }
+    catch (e: any) { handleBackendNotification(e?.response?.data || e); }
   };
   const handleRestore = async (c: Cosecha) => {
     try { await restoreCosecha(c.id); }
-    catch (e: any) { handleBackendNotification(e?.response?.data?.notification || e); }
+    catch (e: any) { handleBackendNotification(e?.response?.data || e); }
   };
   const handleToggleFinal = async (c: Cosecha) => {
     try { await toggleFinalizada(c.id); }
-    catch (e: any) { handleBackendNotification(e?.response?.data?.notification || e); }
+    catch (e: any) { handleBackendNotification(e?.response?.data || e); }
   };
 
   // Navegar a Finanzas por Cosecha

--- a/frontend/src/modules/gestion_huerta/pages/FinanzasPorCosecha.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/FinanzasPorCosecha.tsx
@@ -75,8 +75,9 @@ const FinanzasPorCosecha: React.FC = () => {
         setTempInfo(info);
 
         const origenId = huertaId ?? huertaRentadaId!;
+        const tipo = huertaId ? 'propia' : 'rentada';
         dispatch(setBreadcrumbs([
-          ...breadcrumbRoutes.cosechasList(origenId, info.huerta_nombre, info.año, temporadaId),
+          ...breadcrumbRoutes.cosechasList(origenId, info.huerta_nombre, info.año, temporadaId, tipo),
           { label: 'Ventas & Inversiones', path: '' }
         ]));
       })

--- a/frontend/src/modules/gestion_huerta/services/huertaRentadaService.ts
+++ b/frontend/src/modules/gestion_huerta/services/huertaRentadaService.ts
@@ -83,4 +83,10 @@ export const huertaRentadaService = {
     }>(`/huerta/huertas-rentadas/${id}/restaurar/`);
     return data;
   },
+
+  getById(id: number): Promise<{ data: { huerta_rentada: HuertaRentada } }> {
+    return apiClient
+      .get<HuertaRentada>(`/huerta/huertas-rentadas/${id}/`)
+      .then(res => ({ data: { huerta_rentada: res.data } }));
+  },
 };

--- a/frontend/src/modules/gestion_huerta/services/huertaService.ts
+++ b/frontend/src/modules/gestion_huerta/services/huertaService.ts
@@ -84,4 +84,10 @@ export const huertaService = {
     }>(`/huerta/huertas/${id}/restaurar/`);
     return data;
   },
+
+  getById(id: number): Promise<{ data: { huerta: Huerta } }> {
+    return apiClient
+      .get<Huerta>(`/huerta/huertas/${id}/`)
+      .then(res => ({ data: { huerta: res.data } }));
+  },
 };


### PR DESCRIPTION
## Summary
- Show huerta name from serializer and enforce 6-cosecha limit before name uniqueness
- Persist breadcrumbs and fetch huerta info for Temporadas, fix breadcrumb routes
- Handle notifications correctly and reset state when leaving Cosechas

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f708c818832cb67e22e5ad7ebcf2