### PR TITLE
Fix harvest limit notification and breadcrumb navigation

### DIFF
--- a/backend/gestion_huerta/views/cosechas_views.py
+++ b/backend/gestion_huerta/views/cosechas_views.py
@@ -32,27 +32,28 @@ def _map_cosecha_validation_errors(errors: dict) -> tuple[str, dict]:
         if k in errors:
             buckets += _texts(errors[k])
 
-    for msg in buckets:
-        txt = msg.strip()
+    msgs = [m.strip() for m in buckets]
 
+    if "Esta temporada ya tiene el máximo de 6 cosechas permitidas." in msgs:
+        return "cosecha_limite_temporada", {"errors": errors}
+
+    for msg in msgs:
         # Mensajes exactos del CosechaSerializer / modelo
-        if txt == "La cosecha debe pertenecer a una temporada.":
+        if msg == "La cosecha debe pertenecer a una temporada.":
             return "cosecha_temporada_requerida", {"errors": errors}
-        if txt == "La fecha de fin no puede ser anterior a la fecha de inicio.":
+        if msg == "La fecha de fin no puede ser anterior a la fecha de inicio.":
             return "cosecha_fechas_incoherentes", {"errors": errors}
-        if txt == "No se pueden crear cosechas en una temporada archivada.":
+        if msg == "No se pueden crear cosechas en una temporada archivada.":
             return "cosecha_temporada_archivada", {"errors": errors}
-        if txt == "No se pueden crear cosechas en una temporada finalizada.":
+        if msg == "No se pueden crear cosechas en una temporada finalizada.":
             return "cosecha_temporada_finalizada", {"errors": errors}
-        if txt == "Esta temporada ya tiene el máximo de 6 cosechas permitidas.":
-            return "cosecha_limite_temporada", {"errors": errors}
-        if txt == "Ya existe una cosecha con ese nombre en esta temporada.":
+        if msg == "Ya existe una cosecha con ese nombre en esta temporada.":
             return "cosecha_duplicada", {"errors": errors}
-        if txt == "Ya existe una cosecha activa en esta temporada.":
+        if msg == "Ya existe una cosecha activa en esta temporada.":
             return "cosecha_activa_existente", {"errors": errors}
-        if txt == "No puedes cambiar la temporada de una cosecha existente.":
+        if msg == "No puedes cambiar la temporada de una cosecha existente.":
             return "cosecha_cambiar_temporada_prohibido", {"errors": errors}
-        if txt == "El nombre de la cosecha debe tener al menos 3 caracteres.":
+        if msg == "El nombre de la cosecha debe tener al menos 3 caracteres.":
             return "cosecha_nombre_corto", {"errors": errors}
 
     # Fallback genérico

--- a/frontend/src/global/constants/breadcrumbRoutes.ts
+++ b/frontend/src/global/constants/breadcrumbRoutes.ts
@@ -12,7 +12,7 @@ export const breadcrumbRoutes = {
     huertaId: number,
     huertaName: string
   ): Crumb[] => [
-    { label: `Huertas – ${huertaName}`, path: `/huertas?huerta_id=${huertaId}` },
+    { label: `Huertas – ${huertaName}`, path: '/huertas' },
     { label: 'Temporadas',               path: `/temporadas?huerta_id=${huertaId}` },
   ],
 
@@ -23,7 +23,7 @@ export const breadcrumbRoutes = {
     año: number,
     temporadaId: number    // ← nuevo parámetro
   ): Crumb[] => [
-    { label: `Huertas – ${huertaName}`, path: `/huertas?huerta_id=${huertaId}` },
+    { label: `Huertas – ${huertaName}`, path: '/huertas' },
     { label: `Temporada ${año}`,        path: `/temporadas?huerta_id=${huertaId}` },
     { label: 'Cosechas',                path: `/cosechas?temporada_id=${temporadaId}` }, // ← ahora sí enlaza
   ],
@@ -34,7 +34,7 @@ export const breadcrumbRoutes = {
     huertaName: string,
     año: number
   ): Crumb[] => [
-    { label: `Huertas – ${huertaName}`,     path: `/huertas?huerta_id=${huertaId}` },
+    { label: `Huertas – ${huertaName}`,     path: '/huertas' },
     { label: `Temporada ${año}`,            path: `/temporadas?huerta_id=${huertaId}` },
     { label: 'Ventas & Inversiones',        path: '' /* permanece en la vista actual */ },
   ],

--- a/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
@@ -91,7 +91,8 @@ const Cosechas: React.FC = () => {
   // Comunicar temporada al slice
   useEffect(() => {
     setTemporadaId(temporadaId);
-  }, [temporadaId]);
+    return () => { setTemporadaId(null); };
+  }, [temporadaId, setTemporadaId]);
 
   // Lógica de creación
   const totalCosechas = meta.count;
@@ -141,7 +142,7 @@ const Cosechas: React.FC = () => {
     try {
       await addCosecha({ temporada: temporadaId, nombre });
     } catch (e: any) {
-      handleBackendNotification(e?.response?.data?.notification || e);
+      handleBackendNotification(e?.notification || e?.response?.data?.notification || e);
     }
   };
 
@@ -156,7 +157,7 @@ const Cosechas: React.FC = () => {
       setEditOpen(false);
       setEditTarget(null);
     } catch (e: any) {
-      handleBackendNotification(e?.response?.data?.notification || e);
+      handleBackendNotification(e?.notification || e?.response?.data?.notification || e);
     }
   };
 
@@ -167,7 +168,7 @@ const Cosechas: React.FC = () => {
     try {
       await removeCosecha(delId);
     } catch (e: any) {
-      handleBackendNotification(e?.response?.data?.notification || e);
+      handleBackendNotification(e?.notification || e?.response?.data?.notification || e);
     } finally {
       setDelId(null);
     }
@@ -176,15 +177,15 @@ const Cosechas: React.FC = () => {
   // Acciones fila
   const handleArchive = async (c: Cosecha) => {
     try { await archiveCosecha(c.id); }
-    catch (e: any) { handleBackendNotification(e?.response?.data?.notification || e); }
+    catch (e: any) { handleBackendNotification(e?.notification || e?.response?.data?.notification || e); }
   };
   const handleRestore = async (c: Cosecha) => {
     try { await restoreCosecha(c.id); }
-    catch (e: any) { handleBackendNotification(e?.response?.data?.notification || e); }
+    catch (e: any) { handleBackendNotification(e?.notification || e?.response?.data?.notification || e); }
   };
   const handleToggleFinal = async (c: Cosecha) => {
     try { await toggleFinalizada(c.id); }
-    catch (e: any) { handleBackendNotification(e?.response?.data?.notification || e); }
+    catch (e: any) { handleBackendNotification(e?.notification || e?.response?.data?.notification || e); }
   };
 
   // Navegar a Finanzas por Cosecha

--- a/frontend/src/modules/gestion_huerta/pages/Temporadas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Temporadas.tsx
@@ -104,8 +104,12 @@ const Temporadas: React.FC = () => {
     } else {
       dispatch(clearBreadcrumbs());
     }
-    return () => { dispatch(clearBreadcrumbs()); };
-  }, [dispatch, huertaId, derivedHuertaNombre]);
+    return () => {
+      dispatch(clearBreadcrumbs());
+      setHuerta(null);
+      setHuertaRentada(null);
+    };
+  }, [dispatch, huertaId, derivedHuertaNombre, setHuerta, setHuertaRentada]);
 
   /* ──────────────────── Estados locales ──────────────────── */
   const [spin, setSpin] = useState(false);
@@ -165,7 +169,7 @@ const Temporadas: React.FC = () => {
       await addTemporada(payload);
       handleBackendNotification({ key: 'temporada_create_success', message: 'Temporada creada.', type: 'success' });
     } catch (err: any) {
-      handleBackendNotification(err?.response?.data?.notification || err);
+      handleBackendNotification(err?.notification || err?.response?.data?.notification || err);
     }
   };
 


### PR DESCRIPTION
## Summary
- prioritize harvest limit validation in backend to send correct notification
- reset huerta context and clean breadcrumb links to avoid sticky URLs
- improve error notification handling for seasons and harvest pages

## Testing
- `npm run lint` *(fails: Unexpected any in unrelated files)*
- `python manage.py test` *(fails: Can't connect to local MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a2c481a8832cb0bf6f6b553d336d