### PR TITLE
Use shared module permission for huerta actions

### DIFF
--- a/backend/gestion_huerta/permissions.py
+++ b/backend/gestion_huerta/permissions.py
@@ -1,5 +1,4 @@
-from rest_framework.permissions import BasePermission, DjangoModelPermissions
-from gestion_usuarios.permissions import IsAdmin, IsUser
+from gestion_usuarios.permissions import IsAdmin, IsUser, HasModulePermission
 
 
 class IsAdminForHuerta(IsAdmin):
@@ -26,46 +25,6 @@ class RolePermissionHuertaMixin():
         return request.user and request.user.role in self.allowed_roles
 
 
-class HasHuertaModulePermission(BasePermission):
-    """
-    Admin siempre puede.
-    Usuario normal puede si tiene permiso para ver huertas o propietarios.
-    """
+# Compatibilidad hacia atrás: usar el permiso genérico del módulo de usuarios.
+HasHuertaModulePermission = HasModulePermission
 
-    def has_permission(self, request, view):
-        user = request.user
-        # no autenticado → bloqueado
-        if not user or not user.is_authenticated:
-            return False
-
-        # admin → acceso total
-        if user.role == 'admin':
-            return True
-
-        # usuarios comunes necesitan al menos uno de estos permisos
-        return (
-            user.has_perm('gestion_huerta.view_huerta') or
-            user.has_perm('gestion_huerta.view_propietario')
-        )
-
-class HuertaGranularPermission(DjangoModelPermissions):
-    """
-    Permiso híbrido:
-    - Admin tiene acceso total.
-    - Usuarios normales deben tener permisos específicos (add, change, delete, view).
-    """
-
-    def has_permission(self, request, view):
-        # Acceso total para admins
-        if request.user.is_authenticated and request.user.role == 'admin':
-            return True
-
-        # Para los demás, usa el sistema estándar de DjangoModelPermissions
-        return super().has_permission(request, view)
-
-    def has_object_permission(self, request, view, obj):
-        # Admin tiene acceso directo
-        if request.user.is_authenticated and request.user.role == 'admin':
-            return True
-
-        return super().has_object_permission(request, view, obj)

--- a/backend/gestion_huerta/test/test_permissions_archive_restore.py
+++ b/backend/gestion_huerta/test/test_permissions_archive_restore.py
@@ -1,0 +1,74 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from gestion_huerta.models import Propietario, Huerta
+
+
+class ArchiveRestorePermissionTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            telefono="1234567890",
+            password="pass",
+            nombre="Normal",
+            apellido="User",
+            role="usuario",
+        )
+        # Usuario con permisos básicos de ver/agregar huertas
+        for codename in ["view_huerta", "add_huerta"]:
+            perm = Permission.objects.get(codename=codename)
+            self.user.user_permissions.add(perm)
+
+        self.propietario = Propietario.objects.create(
+            nombre="Juan",
+            apellidos="Pérez",
+            telefono="1111111111",
+            direccion="Calle 1",
+        )
+        self.huerta = Huerta.objects.create(
+            nombre="Mi huerta",
+            ubicacion="Ubic",
+            variedades="Var",
+            hectareas=1.0,
+            propietario=self.propietario,
+        )
+
+    def test_user_without_archive_permission_cannot_archive(self):
+        self.client.force_authenticate(self.user)
+        url = reverse("huerta:huerta-archivar", args=[self.huerta.id])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_with_archive_permission_can_archive(self):
+        perm = Permission.objects.get(codename="archive_huerta")
+        self.user.user_permissions.add(perm)
+        self.client.force_authenticate(self.user)
+        url = reverse("huerta:huerta-archivar", args=[self.huerta.id])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.huerta.refresh_from_db()
+        self.assertFalse(self.huerta.is_active)
+
+    def test_user_without_restore_permission_cannot_restore(self):
+        self.huerta.is_active = False
+        self.huerta.save(update_fields=["is_active"])
+        self.client.force_authenticate(self.user)
+        url = reverse("huerta:huerta-restaurar", args=[self.huerta.id])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_with_restore_permission_can_restore(self):
+        self.huerta.is_active = False
+        self.huerta.save(update_fields=["is_active"])
+        perm = Permission.objects.get(codename="restore_huerta")
+        self.user.user_permissions.add(perm)
+        self.client.force_authenticate(self.user)
+        url = reverse("huerta:huerta-restaurar", args=[self.huerta.id])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.huerta.refresh_from_db()
+        self.assertTrue(self.huerta.is_active)
+

--- a/backend/gestion_huerta/views/categoria_inversion_views.py
+++ b/backend/gestion_huerta/views/categoria_inversion_views.py
@@ -8,7 +8,7 @@ from django.db import transaction
 from gestion_huerta.models import CategoriaInversion
 from gestion_huerta.serializers import CategoriaInversionSerializer
 from gestion_huerta.views.huerta_views import NotificationMixin
-from gestion_huerta.permissions import HasHuertaModulePermission, HuertaGranularPermission
+from gestion_usuarios.permissions import HasModulePermission
 from agroproductores_risol.utils.pagination import GenericPagination
 from gestion_huerta.utils.activity import registrar_actividad
 from gestion_huerta.utils.audit import ViewSetAuditMixin
@@ -55,7 +55,7 @@ class CategoriaInversionViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.M
     """
     serializer_class   = CategoriaInversionSerializer
     pagination_class   = GenericPagination
-    permission_classes = [IsAuthenticated, HasHuertaModulePermission, HuertaGranularPermission]
+    permission_classes = [IsAuthenticated, HasModulePermission]
     filter_backends    = [filters.SearchFilter, filters.OrderingFilter]
     search_fields      = ['nombre']
     ordering_fields    = ['nombre', 'id']
@@ -74,7 +74,7 @@ class CategoriaInversionViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.M
     }
 
     def get_permissions(self):
-        # Hace visible a HasHuertaModulePermission qué codenames exigir
+        # Hace visible a HasModulePermission qué codenames exigir
         self.required_permissions = self._perm_map.get(self.action, [])
         return [p() for p in self.permission_classes]
 

--- a/backend/gestion_huerta/views/cosechas_views.py
+++ b/backend/gestion_huerta/views/cosechas_views.py
@@ -11,7 +11,7 @@ from gestion_huerta.utils.activity import registrar_actividad
 from gestion_huerta.utils.audit import ViewSetAuditMixin
 from agroproductores_risol.utils.pagination import GenericPagination
 from gestion_huerta.views.huerta_views import NotificationMixin
-from gestion_huerta.permissions import HasHuertaModulePermission, HuertaGranularPermission
+from gestion_usuarios.permissions import HasModulePermission
 
 
 # 👉 Límite global por temporada (usado en create)
@@ -94,8 +94,7 @@ class CosechaViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.ModelViewSet
     pagination_class   = GenericPagination
     permission_classes = [
         IsAuthenticated,
-        HasHuertaModulePermission,
-        HuertaGranularPermission,
+        HasModulePermission,
     ]
 
     _perm_map = {

--- a/backend/gestion_huerta/views/huerta_views.py
+++ b/backend/gestion_huerta/views/huerta_views.py
@@ -34,10 +34,7 @@ from gestion_huerta.serializers import (
 )
 
 # Permisos
-from gestion_huerta.permissions import (
-    HasHuertaModulePermission,
-    HuertaGranularPermission,
-)
+from gestion_usuarios.permissions import HasModulePermission
 
 # Utilidades
 from gestion_huerta.utils.activity import registrar_actividad
@@ -86,8 +83,7 @@ class PropietarioViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.ModelVie
 
     permission_classes = [
         IsAuthenticated,
-        HasHuertaModulePermission,   # lee self.required_permissions
-        HuertaGranularPermission,    # si la usas, se mantiene
+        HasModulePermission,
     ]
 
     # 👇 mapa de permisos por acción
@@ -351,8 +347,7 @@ class HuertaViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.ModelViewSet)
 
     permission_classes = [
         IsAuthenticated,
-        HasHuertaModulePermission,
-        HuertaGranularPermission,
+        HasModulePermission,
     ]
 
     _perm_map = {
@@ -544,8 +539,7 @@ class HuertaRentadaViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.ModelV
 
     permission_classes = [
         IsAuthenticated,
-        HasHuertaModulePermission,
-        HuertaGranularPermission,
+        HasModulePermission,
     ]
 
     _perm_map = {
@@ -724,7 +718,7 @@ class HuertasCombinadasViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.Ge
 
     permission_classes = [
         IsAuthenticated,
-        HasHuertaModulePermission,
+        HasModulePermission,
     ]
     # Para listar combinadas basta con tener permiso de ver cualquiera de las dos
     _perm_map = {

--- a/backend/gestion_huerta/views/inversiones_views.py
+++ b/backend/gestion_huerta/views/inversiones_views.py
@@ -12,7 +12,7 @@ from gestion_huerta.serializers import InversionesHuertaSerializer
 from gestion_huerta.utils.activity import registrar_actividad
 from gestion_huerta.utils.audit import ViewSetAuditMixin
 from gestion_huerta.views.huerta_views import NotificationMixin
-from gestion_huerta.permissions import HasHuertaModulePermission, HuertaGranularPermission
+from gestion_usuarios.permissions import HasModulePermission
 
 
 # --------------------------- Helpers de mapeo de errores ---------------------------
@@ -146,7 +146,7 @@ class InversionHuertaViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.Mode
     )
     serializer_class   = InversionesHuertaSerializer
     pagination_class   = GenericPagination
-    permission_classes = [IsAuthenticated, HasHuertaModulePermission, HuertaGranularPermission]
+    permission_classes = [IsAuthenticated, HasModulePermission]
     filter_backends    = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
     filterset_fields   = ['cosecha', 'temporada', 'categoria', 'huerta', 'huerta_rentada']
     search_fields      = ['descripcion']
@@ -165,7 +165,7 @@ class InversionHuertaViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.Mode
     }
 
     def get_permissions(self):
-        # Hace visible a HasHuertaModulePermission qué codenames exigir
+        # Hace visible a HasModulePermission qué codenames exigir
         self.required_permissions = self._perm_map.get(self.action, [])
         return [p() for p in self.permission_classes]
 

--- a/backend/gestion_huerta/views/temporadas_views.py
+++ b/backend/gestion_huerta/views/temporadas_views.py
@@ -30,7 +30,7 @@ from gestion_huerta.utils.activity import registrar_actividad
 from gestion_huerta.utils.audit    import ViewSetAuditMixin
 from gestion_huerta.views.huerta_views import NotificationMixin
 from agroproductores_risol.utils.pagination import TemporadaPagination
-from gestion_huerta.permissions    import HasHuertaModulePermission, HuertaGranularPermission
+from gestion_usuarios.permissions    import HasModulePermission
 
 
 # ---------------------------------------------------------------------------
@@ -88,7 +88,7 @@ class TemporadaViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.ModelViewS
     )
     serializer_class   = TemporadaSerializer
     pagination_class   = TemporadaPagination
-    permission_classes = [IsAuthenticated, HasHuertaModulePermission, HuertaGranularPermission]
+    permission_classes = [IsAuthenticated, HasModulePermission]
 
     # Mapa base (CRUD + archivar/restaurar)
     _perm_map = {

--- a/backend/gestion_huerta/views/ventas_views.py
+++ b/backend/gestion_huerta/views/ventas_views.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from gestion_huerta.models import Venta, Cosecha
 from gestion_huerta.serializers import VentaSerializer
 from gestion_huerta.views.huerta_views import NotificationMixin
-from gestion_huerta.permissions import HasHuertaModulePermission, HuertaGranularPermission
+from gestion_usuarios.permissions import HasModulePermission
 from agroproductores_risol.utils.pagination import GenericPagination
 from gestion_huerta.utils.activity import registrar_actividad
 from gestion_huerta.utils.audit import ViewSetAuditMixin
@@ -142,7 +142,7 @@ class VentaViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.ModelViewSet):
     queryset           = Venta.objects.select_related('cosecha', 'temporada', 'huerta', 'huerta_rentada').order_by('-fecha_venta')
     serializer_class   = VentaSerializer
     pagination_class   = GenericPagination
-    permission_classes = [IsAuthenticated, HasHuertaModulePermission, HuertaGranularPermission]
+    permission_classes = [IsAuthenticated, HasModulePermission]
     filter_backends    = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
     filterset_fields   = ['cosecha', 'temporada', 'huerta', 'huerta_rentada', 'tipo_mango']
     search_fields      = ['tipo_mango', 'descripcion']


### PR DESCRIPTION
## Summary
- Replace custom `HasHuertaModulePermission` with shared `HasModulePermission`
- Drop `HuertaGranularPermission` and rely on declared codenames for actions
- Add tests ensuring archive/restore require their specific permissions

## Testing
- `python manage.py test` *(fails: Can't connect to local MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68a646e2ec24832c95742587de5c3288