### PR TITLE
Update inversion permission codenames

### DIFF
--- a/frontend/src/modules/gestion_huerta/components/cosecha/CosechaTable.tsx
+++ b/frontend/src/modules/gestion_huerta/components/cosecha/CosechaTable.tsx
@@ -103,7 +103,7 @@ const CosechaTable: React.FC<Props> = ({
             onDelete={isArchived ? () => onDelete(c) : undefined}
           />
           <PermissionButton
-            perm="view_inversion"
+            perm="view_inversioneshuerta"
             variant="outlined"
             size="small"
             onClick={() => onVerFinanzas(c)}

--- a/frontend/src/modules/gestion_huerta/components/finanzas/InversionFormModal.tsx
+++ b/frontend/src/modules/gestion_huerta/components/finanzas/InversionFormModal.tsx
@@ -314,7 +314,7 @@ const InversionFormModal: React.FC<Props> = ({ open, onClose, onSubmit, initialV
                   type="submit"
                   variant="contained"
                   disabled={isSubmitting}
-                  perm={initialValues ? 'change_inversion' : 'add_inversion'}
+                  perm={initialValues ? 'change_inversioneshuerta' : 'add_inversioneshuerta'}
                 >
                   {isSubmitting ? <CircularProgress size={22} /> : 'Guardar'}
                 </PermissionButton>

--- a/frontend/src/modules/gestion_huerta/components/finanzas/InversionTable.tsx
+++ b/frontend/src/modules/gestion_huerta/components/finanzas/InversionTable.tsx
@@ -120,9 +120,9 @@ const InversionTable: React.FC<Props> = ({
           onEdit={!isArchived ? () => onEdit(inv) : undefined}
           onArchiveOrRestore={() => isArchived ? onRestore(inv.id) : onArchive(inv.id)}
           onDelete={isArchived ? () => onDelete(inv.id) : undefined}
-          permEdit="change_inversion"
-          permArchiveOrRestore="archive_inversion"
-          permDelete="delete_inversion"
+          permEdit="change_inversioneshuerta"
+          permArchiveOrRestore={['archive_inversioneshuerta', 'restore_inversioneshuerta']}
+          permDelete="delete_inversioneshuerta"
         />
       );
     }}

--- a/frontend/src/modules/gestion_huerta/components/finanzas/InversionToolbar.tsx
+++ b/frontend/src/modules/gestion_huerta/components/finanzas/InversionToolbar.tsx
@@ -143,7 +143,7 @@ const InversionToolbar: React.FC<Props> = ({
           <Tooltip title={createTooltip || ''}>
             <span>
               <PermissionButton
-                perm="add_inversion"  // ← codename con app-label
+                perm="add_inversioneshuerta"  // ← codename con app-label
                 variant="contained"
                 startIcon={<AddIcon />}
                 onClick={onCreateClick}


### PR DESCRIPTION
## Summary
- replace inversion permission codenames with `inversioneshuerta` equivalents
- ensure actions menu checks for archive and restore permissions separately

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 246 problems (230 errors, 16 warnings))*
- `npm run build` *(fails: Property 'data' does not exist on type '{}')*

------
https://chatgpt.com/codex/tasks/task_e_68a646e75894832ca1a44fdd845e7368