### PR TITLE
fix: update permission redirect path

### DIFF
--- a/backend/gestion_usuarios/utils/constants.py
+++ b/backend/gestion_usuarios/utils/constants.py
@@ -40,7 +40,7 @@ NOTIFICATION_MESSAGES = {
         "message": "Permisos actualizados correctamente back",
         "type": "success",
         "action": "redirect",
-        "target": "/user-permissions"
+        "target": "/users-admin"
     },
     # --- CRUD generales ---
     "create_success": {


### PR DESCRIPTION
## Summary
- fix permission update success redirect to `/users-admin`

## Testing
- `DJANGO_SETTINGS_MODULE=agroproductores_risol.settings pytest` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d0f09c84832c8ce0dbee4888f39b