### PR TITLE
Initialize permissions dialog with current perms

### DIFF
--- a/frontend/src/modules/gestion_usuarios/pages/PermissionsDialog.tsx
+++ b/frontend/src/modules/gestion_usuarios/pages/PermissionsDialog.tsx
@@ -50,6 +50,7 @@ const PermissionsDialog: React.FC<PermissionsDialogProps> = ({
   open,
   onClose,
   userId,
+  currentPerms,
 }) => {
   /* ------------------------------------------------- */
   /*                       STATE                       */
@@ -71,6 +72,8 @@ const PermissionsDialog: React.FC<PermissionsDialogProps> = ({
   /* ------------------------------------------------- */
   useEffect(() => {
     if (!open) return;
+
+    setSelected(currentPerms);
 
     let timer: ReturnType<typeof setTimeout> | undefined;
     (async () => {
@@ -98,7 +101,7 @@ const PermissionsDialog: React.FC<PermissionsDialogProps> = ({
     })();
 
     return () => clearTimeout(timer);
-  }, [open, userId]);
+  }, [open, userId, currentPerms]);
 
   /* ------------------------------------------------- */
   /*                     HANDLERS                      */


### PR DESCRIPTION
## Summary
- preload permissions dialog selection from caller's current perms

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d0f1ead8832cbe476ab83f77cad3