### PR TITLE
Fix restore endpoint for huerta rentada service

### DIFF
--- a/frontend/src/modules/gestion_huerta/pages/Huertas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Huertas.tsx
@@ -32,7 +32,6 @@ import { huertasCombinadasService } from '../services/huertasCombinadasService';
 
 import { handleBackendNotification } from '../../../global/utils/NotificationEngine';
 import { FilterConfig } from '../../../components/common/TableLayout';
-import { isRentada } from '../utils/huertaTypeGuards';
 
 import type { HuertaCreateData, HuertaUpdateData } from '../types/huertaTypes';
 import type { HuertaRentadaCreateData, HuertaRentadaUpdateData } from '../types/huertaRentadaTypes';
@@ -183,7 +182,7 @@ const Huertas: React.FC = () => {
     setModalOpen(false);
   };
 
-  const askDelete = (h: Registro) => setDelDialog({ id: h.id, tipo: isRentada(h) ? 'rentada' : 'propia' });
+  const askDelete = (h: Registro) => setDelDialog({ id: h.id, tipo: h.tipo === 'rentada' ? 'rentada' : 'propia' });
   const confirmDelete = async (): Promise<void> => {
     if (!delDialog) return;
     try {
@@ -201,7 +200,7 @@ const Huertas: React.FC = () => {
 
   const handleArchiveOrRestore = async (h: Registro, arc: boolean): Promise<void> => {
     let res;
-    if (isRentada(h)) {
+    if (h.tipo === 'rentada') {
       res = arc
         ? await huertaRentadaService.restaurar(h.id)
         : await huertaRentadaService.archivar(h.id);
@@ -276,11 +275,11 @@ const Huertas: React.FC = () => {
             filterValues={{ tipo: tipoFiltro, nombre: nombreFiltro, propietario: propietarioFiltro }}
             onFilterChange={handleFilterChange}
             limpiarFiltros={limpiarFiltros}
-            onEdit={h => { setEditTarget({ tipo: isRentada(h) ? 'rentada' : 'propia', data: h }); setModalOpen(true); }}
+            onEdit={h => { setEditTarget({ tipo: h.tipo === 'rentada' ? 'rentada' : 'propia', data: h }); setModalOpen(true); }}
             onDelete={askDelete}
             onArchive={h => handleArchiveOrRestore(h, false)}
             onRestore={h => handleArchiveOrRestore(h, true)}
-            onTemporadas={h => navigate(`/temporadas?huerta_id=${h.id}&tipo=${isRentada(h) ? 'rentada' : 'propia'}`)}
+            onTemporadas={h => navigate(`/temporadas?huerta_id=${h.id}&tipo=${h.tipo === 'rentada' ? 'rentada' : 'propia'}`)}
           />
         </Box>
 

--- a/frontend/src/modules/gestion_huerta/services/huertaRentadaService.ts
+++ b/frontend/src/modules/gestion_huerta/services/huertaRentadaService.ts
@@ -83,7 +83,7 @@ export const huertaRentadaService = {
       success: boolean;
       notification: any;              // 👈
       data: { huerta_rentada_id: number; affected?: AffectedCounts };
-    }>(`/huerta/huertas-rentadas/${id}/archivar/`);
+    }>(`/huerta/huertas-rentadas/${id}/restaurar/`);
     return data;
   },
 

--- a/frontend/src/modules/gestion_huerta/utils/huertaTypeGuards.ts
+++ b/frontend/src/modules/gestion_huerta/utils/huertaTypeGuards.ts
@@ -1,8 +1,0 @@
-// src/modules/gestion_huerta/utils/huertaTypeGuards.ts
-import { HuertaRentada } from '../types/huertaRentadaTypes';
-
-/** Devuelve true si el registro es una huerta rentada */
-export function isRentada(h: any): h is HuertaRentada {
-  return 'monto_renta_palabras' in h;
-}
-


### PR DESCRIPTION
## Summary
- fix restore endpoint for huerta rentada service
- route huerta actions using explicit `tipo` flag instead of unreliable guard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d1bfdf38832c9a6d22d541daa730