### PR TITLE
feat: auto load report data

### DIFF
--- a/backend/gestion_huerta/urls.py
+++ b/backend/gestion_huerta/urls.py
@@ -24,6 +24,7 @@ from gestion_huerta.views.cosechas_views import CosechaViewSet
 from gestion_huerta.views.ventas_views import VentaViewSet
 from gestion_huerta.views.temporadas_views import TemporadaViewSet
 from gestion_huerta.views.registro_actividad import RegistroActividadViewSet
+from gestion_huerta.views.informes_views import InformesViewSet
 app_name = "gestion_huerta"
 
 # ---- router ----
@@ -38,6 +39,7 @@ router.register(r"ventas", VentaViewSet, basename="venta")
 router.register(r"temporadas", TemporadaViewSet, basename="temporada")
 router.register(r'actividad', RegistroActividadViewSet, basename='actividad')
 router.register(r"huertas-combinadas", HuertasCombinadasViewSet, basename="huertas-combinadas")
+router.register(r"informes", InformesViewSet, basename="informes")
 
 # ---- urlpatterns ----
 urlpatterns = [

--- a/backend/gestion_huerta/utils/reporting.py
+++ b/backend/gestion_huerta/utils/reporting.py
@@ -6,8 +6,251 @@ Punto único para construir el contrato de reportes del front:
   "series": [{ id, label, type, data }],
   "tabla": { columns: [...], rows: [...] }
 }
-Implementaremos: 
+Implementaremos:
  - aggregates_for_cosecha(), aggregates_for_temporada(), aggregates_for_huerta()
  - series_for_cosecha(), series_for_temporada(), series_for_huerta()
 """
-# TODO: implementar funciones arriba mencionadas
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Dict, Iterable, List, Union
+
+from django.db.models import F, Sum, Value, ExpressionWrapper, DecimalField
+from django.db.models.functions import Coalesce
+
+from gestion_huerta.models import (
+    Cosecha,
+    Temporada,
+    Huerta,
+    HuertaRentada,
+    InversionesHuerta,
+    Venta,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers internos
+# ---------------------------------------------------------------------------
+
+def _money(value: Decimal | None) -> float:
+    """Convierte Decimals a float para el contrato JSON."""
+    if value is None:
+        return 0.0
+    return float(value)
+
+
+def _sum_inversiones(qs: Iterable[InversionesHuerta]) -> Decimal:
+    expr = F("gastos_insumos") + F("gastos_mano_obra")
+    return qs.aggregate(total=Coalesce(Sum(expr), Value(Decimal("0"))))["total"]
+
+
+def _sum_ventas(qs: Iterable[Venta]) -> Decimal:
+    expr = ExpressionWrapper(
+        F("num_cajas") * F("precio_por_caja"),
+        output_field=DecimalField(max_digits=18, decimal_places=2),
+    )
+    return qs.aggregate(total=Coalesce(Sum(expr), Value(Decimal("0"))))["total"]
+
+
+def _sum_gastos_venta(qs: Iterable[Venta]) -> Decimal:
+    return qs.aggregate(total=Coalesce(Sum("gasto"), Value(Decimal("0"))))["total"]
+
+
+# ---------------------------------------------------------------------------
+#  Construcción de reportes
+# ---------------------------------------------------------------------------
+
+def aggregates_for_cosecha(cosecha: Cosecha) -> List[Dict[str, Any]]:
+    """Devuelve KPIs principales para una cosecha."""
+    inversiones = cosecha.inversiones.filter(is_active=True)
+    ventas = cosecha.ventas.filter(is_active=True)
+
+    total_inv = _sum_inversiones(inversiones)
+    total_ven = _sum_ventas(ventas)
+    gasto_ven = _sum_gastos_venta(ventas)
+    ganancia = total_ven - total_inv - gasto_ven
+    roi = (ganancia / total_inv * 100) if total_inv else Decimal("0")
+
+    return [
+        {"id": "inversiones", "label": "Inversiones", "value": _money(total_inv)},
+        {"id": "ventas", "label": "Ventas", "value": _money(total_ven)},
+        {"id": "ganancia", "label": "Ganancia neta", "value": _money(ganancia)},
+        {
+            "id": "roi",
+            "label": "ROI %",
+            "value": float(roi),
+            "hint": "Ganancia / Inversiones",
+        },
+    ]
+
+
+def aggregates_for_temporada(temporada: Temporada) -> List[Dict[str, Any]]:
+    """KPIs de una temporada completa."""
+    inversiones = temporada.inversiones.filter(is_active=True)
+    ventas = temporada.ventas.filter(is_active=True)
+
+    total_inv = _sum_inversiones(inversiones)
+    total_ven = _sum_ventas(ventas)
+    gasto_ven = _sum_gastos_venta(ventas)
+    ganancia = total_ven - total_inv - gasto_ven
+    roi = (ganancia / total_inv * 100) if total_inv else Decimal("0")
+
+    return [
+        {"id": "inversiones", "label": "Inversiones", "value": _money(total_inv)},
+        {"id": "ventas", "label": "Ventas", "value": _money(total_ven)},
+        {"id": "ganancia", "label": "Ganancia neta", "value": _money(ganancia)},
+        {
+            "id": "roi",
+            "label": "ROI %",
+            "value": float(roi),
+            "hint": "Ganancia / Inversiones",
+        },
+    ]
+
+
+def aggregates_for_huerta(origen: Union[Huerta, HuertaRentada]) -> List[Dict[str, Any]]:
+    """KPIs históricos de una huerta (propia o rentada)."""
+    temporadas = origen.temporadas.filter(is_active=True)
+    inversiones = InversionesHuerta.objects.filter(temporada__in=temporadas, is_active=True)
+    ventas = Venta.objects.filter(temporada__in=temporadas, is_active=True)
+
+    total_inv = _sum_inversiones(inversiones)
+    total_ven = _sum_ventas(ventas)
+    gasto_ven = _sum_gastos_venta(ventas)
+    ganancia = total_ven - total_inv - gasto_ven
+    roi = (ganancia / total_inv * 100) if total_inv else Decimal("0")
+
+    return [
+        {"id": "inversiones", "label": "Inversiones", "value": _money(total_inv)},
+        {"id": "ventas", "label": "Ventas", "value": _money(total_ven)},
+        {"id": "ganancia", "label": "Ganancia neta", "value": _money(ganancia)},
+        {
+            "id": "roi",
+            "label": "ROI %",
+            "value": float(roi),
+            "hint": "Ganancia / Inversiones",
+        },
+    ]
+
+
+def series_for_cosecha(cosecha: Cosecha) -> List[Dict[str, Any]]:
+    ventas = (
+        cosecha.ventas.filter(is_active=True)
+        .values("fecha_venta")
+        .annotate(total=Sum(F("num_cajas") * F("precio_por_caja")))
+        .order_by("fecha_venta")
+    )
+    data = [{"x": v["fecha_venta"].isoformat(), "y": float(v["total"])} for v in ventas]
+    return [{"id": "ventas", "label": "Ventas", "type": "bar", "data": data}]
+
+
+def series_for_temporada(temporada: Temporada) -> List[Dict[str, Any]]:
+    ventas = (
+        temporada.ventas.filter(is_active=True)
+        .values("cosecha__nombre")
+        .annotate(total=Sum(F("num_cajas") * F("precio_por_caja")))
+        .order_by("cosecha__nombre")
+    )
+    data = [{"x": v["cosecha__nombre"], "y": float(v["total"])} for v in ventas]
+    return [{"id": "ventas", "label": "Ventas por Cosecha", "type": "bar", "data": data}]
+
+
+def series_for_huerta(origen: Union[Huerta, HuertaRentada]) -> List[Dict[str, Any]]:
+    ventas = (
+        Venta.objects.filter(temporada__in=origen.temporadas.filter(is_active=True), is_active=True)
+        .values("temporada__año")
+        .annotate(total=Sum(F("num_cajas") * F("precio_por_caja")))
+        .order_by("temporada__año")
+    )
+    data = [{"x": v["temporada__año"], "y": float(v["total"])} for v in ventas]
+    return [{"id": "ventas", "label": "Ventas por Año", "type": "line", "data": data}]
+
+
+def tabla_for_cosecha(cosecha: Cosecha) -> Dict[str, Any]:
+    rows = [
+        {
+            "fecha": v.fecha_venta.isoformat(),
+            "tipo": v.tipo_mango,
+            "cajas": v.num_cajas,
+            "precio": float(v.precio_por_caja),
+            "total": float(v.total_venta),
+        }
+        for v in cosecha.ventas.filter(is_active=True).order_by("fecha_venta")
+    ]
+    columns = [
+        {"id": "fecha", "label": "Fecha"},
+        {"id": "tipo", "label": "Tipo Mango"},
+        {"id": "cajas", "label": "Cajas", "align": "right"},
+        {"id": "precio", "label": "Precio/Caja", "align": "right"},
+        {"id": "total", "label": "Total", "align": "right"},
+    ]
+    return {"columns": columns, "rows": rows}
+
+
+def tabla_for_temporada(temporada: Temporada) -> Dict[str, Any]:
+    rows = []
+    for cosecha in temporada.cosechas.filter(is_active=True).order_by("nombre"):
+        inv = _sum_inversiones(cosecha.inversiones.filter(is_active=True))
+        ven = _sum_ventas(cosecha.ventas.filter(is_active=True))
+        rows.append(
+            {
+                "cosecha": cosecha.nombre,
+                "inversiones": _money(inv),
+                "ventas": _money(ven),
+                "ganancia": _money(ven - inv),
+            }
+        )
+    columns = [
+        {"id": "cosecha", "label": "Cosecha"},
+        {"id": "inversiones", "label": "Inversiones", "align": "right"},
+        {"id": "ventas", "label": "Ventas", "align": "right"},
+        {"id": "ganancia", "label": "Ganancia", "align": "right"},
+    ]
+    return {"columns": columns, "rows": rows}
+
+
+def tabla_for_huerta(origen: Union[Huerta, HuertaRentada]) -> Dict[str, Any]:
+    rows = []
+    for temp in origen.temporadas.filter(is_active=True).order_by("año"):
+        inv = _sum_inversiones(temp.inversiones.filter(is_active=True))
+        ven = _sum_ventas(temp.ventas.filter(is_active=True))
+        rows.append(
+            {
+                "año": temp.año,
+                "inversiones": _money(inv),
+                "ventas": _money(ven),
+                "ganancia": _money(ven - inv),
+            }
+        )
+    columns = [
+        {"id": "año", "label": "Año"},
+        {"id": "inversiones", "label": "Inversiones", "align": "right"},
+        {"id": "ventas", "label": "Ventas", "align": "right"},
+        {"id": "ganancia", "label": "Ganancia", "align": "right"},
+    ]
+    return {"columns": columns, "rows": rows}
+
+
+def build_cosecha_report(cosecha: Cosecha) -> Dict[str, Any]:
+    return {
+        "kpis": aggregates_for_cosecha(cosecha),
+        "series": series_for_cosecha(cosecha),
+        "tabla": tabla_for_cosecha(cosecha),
+    }
+
+
+def build_temporada_report(temporada: Temporada) -> Dict[str, Any]:
+    return {
+        "kpis": aggregates_for_temporada(temporada),
+        "series": series_for_temporada(temporada),
+        "tabla": tabla_for_temporada(temporada),
+    }
+
+
+def build_huerta_report(origen: Union[Huerta, HuertaRentada]) -> Dict[str, Any]:
+    return {
+        "kpis": aggregates_for_huerta(origen),
+        "series": series_for_huerta(origen),
+        "tabla": tabla_for_huerta(origen),
+    }
+

--- a/backend/gestion_huerta/views/informes_views.py
+++ b/backend/gestion_huerta/views/informes_views.py
@@ -6,7 +6,101 @@ ViewSet de informes con 3 acciones GET:
  - /informes/huertas/{id}/perfil/
 Devuelve siempre el contrato {kpis, series, tabla}.
 """
-# TODO: class ReportesViewSet(viewsets.GenericViewSet): ...
-# TODO: @action(detail=True, methods=["get"], url_path="cosechas")
-# TODO: @action(detail=True, methods=["get"], url_path="temporadas")
-# TODO: @action(detail=True, methods=["get"], url_path="huertas/perfil")
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+
+from gestion_huerta.models import Cosecha, Temporada, Huerta, HuertaRentada
+from gestion_huerta.utils.notification_handler import NotificationHandler
+from gestion_huerta.utils.audit import ViewSetAuditMixin
+from gestion_usuarios.permissions import HasModulePermission
+from gestion_huerta.utils.reporting import (
+    build_cosecha_report,
+    build_temporada_report,
+    build_huerta_report,
+)
+
+
+class NotificationMixin:
+    """Helper para respuestas uniformes"""
+
+    def notify(self, *, key: str, data=None, status_code=status.HTTP_200_OK):
+        return NotificationHandler.generate_response(
+            message_key=key, data=data or {}, status_code=status_code
+        )
+
+
+class InformesViewSet(ViewSetAuditMixin, NotificationMixin, viewsets.GenericViewSet):
+    """Acciones de informes para cosechas, temporadas y huertas."""
+
+    permission_classes = [IsAuthenticated, HasModulePermission]
+
+    _perm_map = {
+        "cosecha": ["view_cosecha"],
+        "temporada": ["view_temporada"],
+        "perfil": ["view_huerta"],
+    }
+
+    def get_permissions(self):  # pragma: no cover - mapea permisos por acción
+        self.required_permissions = self._perm_map.get(self.action, ["view_huerta"])
+        return [p() for p in self.permission_classes]
+
+    # ------------------------------------------------------------------
+    # /informes/cosechas/{id}/
+    # ------------------------------------------------------------------
+    @action(detail=False, methods=["get"], url_path=r"cosechas/(?P<cosecha_id>[^/.]+)")
+    def cosecha(self, request, cosecha_id: str | None = None):
+        try:
+            cosecha = Cosecha.objects.get(pk=cosecha_id, is_active=True)
+        except Cosecha.DoesNotExist:
+            return self.notify(
+                key="not_found",
+                data={"cosecha_id": cosecha_id},
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+
+        data = build_cosecha_report(cosecha)
+        return self.notify(key="data_processed_success", data=data)
+
+    # ------------------------------------------------------------------
+    # /informes/temporadas/{id}/
+    # ------------------------------------------------------------------
+    @action(detail=False, methods=["get"], url_path=r"temporadas/(?P<temporada_id>[^/.]+)")
+    def temporada(self, request, temporada_id: str | None = None):
+        try:
+            temporada = Temporada.objects.get(pk=temporada_id, is_active=True)
+        except Temporada.DoesNotExist:
+            return self.notify(
+                key="not_found",
+                data={"temporada_id": temporada_id},
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+
+        data = build_temporada_report(temporada)
+        return self.notify(key="data_processed_success", data=data)
+
+    # ------------------------------------------------------------------
+    # /informes/huertas/{id}/perfil/
+    # ------------------------------------------------------------------
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path=r"huertas/(?P<huerta_id>[^/.]+)/perfil",
+    )
+    def perfil(self, request, huerta_id: str | None = None):
+        origen: Huerta | HuertaRentada | None = None
+        try:
+            origen = Huerta.objects.get(pk=huerta_id, is_active=True)
+        except Huerta.DoesNotExist:
+            try:
+                origen = HuertaRentada.objects.get(pk=huerta_id, is_active=True)
+            except HuertaRentada.DoesNotExist:
+                return self.notify(
+                    key="not_found",
+                    data={"huerta_id": huerta_id},
+                    status_code=status.HTTP_404_NOT_FOUND,
+                )
+
+        data = build_huerta_report(origen)
+        return self.notify(key="data_processed_success", data=data)
+

--- a/frontend/modules/gestion_huerta/components/reportes/ReportView.tsx
+++ b/frontend/modules/gestion_huerta/components/reportes/ReportView.tsx
@@ -1,0 +1,54 @@
+// frontend/modules/gestion_huerta/components/reportes/ReportView.tsx
+import React from 'react';
+import { Grid, Table, TableBody, TableCell, TableHead, TableRow, Paper } from '@mui/material';
+import type { ReporteContrato } from '../../types/reportTypes';
+import KPICard from './common/KPICard';
+import ReportChart from './common/ReportChart';
+
+interface Props {
+  data: ReporteContrato;
+}
+
+const ReportView: React.FC<Props> = ({ data }) => (
+  <Grid container spacing={3}>
+    {data.kpis.map((kpi) => (
+      <Grid item xs={12} md={3} key={kpi.id}>
+        <KPICard kpi={kpi} />
+      </Grid>
+    ))}
+
+    {data.series.map((serie) => (
+      <Grid item xs={12} key={serie.id}>
+        <ReportChart serie={serie} />
+      </Grid>
+    ))}
+
+    <Grid item xs={12}>
+      <Paper>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              {data.tabla.columns.map((col) => (
+                <TableCell key={col.id} align={col.align}>{col.label}</TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.tabla.rows.map((row, idx) => (
+              <TableRow key={idx}>
+                {data.tabla.columns.map((col) => (
+                  <TableCell key={col.id} align={col.align}>
+                    {row[col.id]}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    </Grid>
+  </Grid>
+);
+
+export default ReportView;
+

--- a/frontend/modules/gestion_huerta/components/reportes/common/KPICard.tsx
+++ b/frontend/modules/gestion_huerta/components/reportes/common/KPICard.tsx
@@ -1,0 +1,29 @@
+// frontend/modules/gestion_huerta/components/reportes/common/KPICard.tsx
+import React from 'react';
+import { Card, CardContent, Typography } from '@mui/material';
+import type { KPI } from '../../../types/reportTypes';
+
+interface Props {
+  kpi: KPI;
+}
+
+const KPICard: React.FC<Props> = ({ kpi }) => (
+  <Card sx={{ minWidth: 200 }} variant="outlined">
+    <CardContent>
+      <Typography variant="h6" gutterBottom>
+        {kpi.label}
+      </Typography>
+      <Typography variant="h5" color="primary">
+        {kpi.value.toLocaleString('es-MX')}
+      </Typography>
+      {kpi.hint && (
+        <Typography variant="caption" color="text.secondary">
+          {kpi.hint}
+        </Typography>
+      )}
+    </CardContent>
+  </Card>
+);
+
+export default KPICard;
+

--- a/frontend/modules/gestion_huerta/components/reportes/common/ReportChart.tsx
+++ b/frontend/modules/gestion_huerta/components/reportes/common/ReportChart.tsx
@@ -1,0 +1,43 @@
+// frontend/modules/gestion_huerta/components/reportes/common/ReportChart.tsx
+import React from 'react';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from 'recharts';
+import type { Serie } from '../../../types/reportTypes';
+
+interface Props {
+  serie: Serie;
+}
+
+const ReportChart: React.FC<Props> = ({ serie }) => (
+  <ResponsiveContainer width="100%" height={300}>
+    {serie.type === 'bar' ? (
+      <BarChart data={serie.data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="x" />
+        <YAxis />
+        <Tooltip />
+        <Bar dataKey="y" fill="#8884d8" />
+      </BarChart>
+    ) : (
+      <LineChart data={serie.data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="x" />
+        <YAxis />
+        <Tooltip />
+        <Line type="monotone" dataKey="y" stroke="#82ca9d" />
+      </LineChart>
+    )}
+  </ResponsiveContainer>
+);
+
+export default ReportChart;
+

--- a/frontend/modules/gestion_huerta/components/reportes/common/ReportToolbar.tsx
+++ b/frontend/modules/gestion_huerta/components/reportes/common/ReportToolbar.tsx
@@ -1,0 +1,55 @@
+// frontend/modules/gestion_huerta/components/reportes/common/ReportToolbar.tsx
+import React, { useEffect, useState } from 'react';
+import { Box, Button, MenuItem, TextField } from '@mui/material';
+
+interface Props {
+  onFetch: (tipo: 'cosecha' | 'temporada' | 'huerta', id: number) => void;
+  initialTipo?: 'cosecha' | 'temporada' | 'huerta';
+  initialId?: number;
+}
+
+const ReportToolbar: React.FC<Props> = ({ onFetch, initialTipo, initialId }) => {
+  const [tipo, setTipo] = useState<'cosecha' | 'temporada' | 'huerta'>(initialTipo ?? 'cosecha');
+  const [id, setId] = useState(initialId ? String(initialId) : '');
+
+  useEffect(() => {
+    if (initialTipo) setTipo(initialTipo);
+    if (initialId !== undefined) setId(String(initialId));
+  }, [initialTipo, initialId]);
+
+  const handleSubmit = () => {
+    const num = parseInt(id, 10);
+    if (!Number.isNaN(num)) {
+      onFetch(tipo, num);
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+      <TextField
+        select
+        label="Tipo"
+        value={tipo}
+        onChange={(e) => setTipo(e.target.value as any)}
+        size="small"
+      >
+        <MenuItem value="cosecha">Cosecha</MenuItem>
+        <MenuItem value="temporada">Temporada</MenuItem>
+        <MenuItem value="huerta">Huerta</MenuItem>
+      </TextField>
+      <TextField
+        label="ID"
+        value={id}
+        onChange={(e) => setId(e.target.value)}
+        size="small"
+        type="number"
+      />
+      <Button variant="contained" onClick={handleSubmit} sx={{ alignSelf: 'center' }}>
+        Generar
+      </Button>
+    </Box>
+  );
+};
+
+export default ReportToolbar;
+

--- a/frontend/modules/gestion_huerta/hooks/useReporte.ts
+++ b/frontend/modules/gestion_huerta/hooks/useReporte.ts
@@ -1,0 +1,54 @@
+// frontend/modules/gestion_huerta/hooks/useReporte.ts
+import { useState } from 'react';
+import { reporteService } from '../services/reporteService';
+import { ReporteContrato } from '../types/reportTypes';
+
+export function useReporte() {
+  const [data, setData] = useState<ReporteContrato | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCosecha = async (id: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await reporteService.getCosecha(id);
+      setData(res);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchTemporada = async (id: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await reporteService.getTemporada(id);
+      setData(res);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchHuerta = async (id: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await reporteService.getHuertaPerfil(id);
+      setData(res);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { data, loading, error, fetchCosecha, fetchTemporada, fetchHuerta };
+}
+
+export default useReporte;
+

--- a/frontend/modules/gestion_huerta/pages/Reportes.tsx
+++ b/frontend/modules/gestion_huerta/pages/Reportes.tsx
@@ -1,0 +1,43 @@
+// frontend/modules/gestion_huerta/pages/Reportes.tsx
+import React, { useEffect } from 'react';
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { useLocation } from 'react-router-dom';
+import ReportToolbar from '../components/reportes/common/ReportToolbar';
+import ReportView from '../components/reportes/ReportView';
+import useReporte from '../hooks/useReporte';
+
+const Reportes: React.FC = () => {
+  const { data, loading, fetchCosecha, fetchTemporada, fetchHuerta } = useReporte();
+  const location = useLocation() as { state?: { tipo?: 'cosecha' | 'temporada' | 'huerta'; id?: number } };
+
+  const handleFetch = (tipo: 'cosecha' | 'temporada' | 'huerta', id: number) => {
+    if (tipo === 'cosecha') fetchCosecha(id);
+    else if (tipo === 'temporada') fetchTemporada(id);
+    else fetchHuerta(id);
+  };
+
+  // Si venimos desde una tabla con estado, generar el reporte automáticamente
+  useEffect(() => {
+    const st = location.state;
+    if (st?.id && st.tipo) {
+      handleFetch(st.tipo, st.id);
+    }
+  }, [location.state]);
+
+  const initialTipo = location.state?.tipo;
+  const initialId = location.state?.id;
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" gutterBottom>
+        Reportes de Producción
+      </Typography>
+      <ReportToolbar onFetch={handleFetch} initialTipo={initialTipo} initialId={initialId} />
+      {loading && <CircularProgress sx={{ mt: 2 }} />}
+      {!loading && data && <ReportView data={data} />}
+    </Box>
+  );
+};
+
+export default Reportes;
+

--- a/frontend/modules/gestion_huerta/services/reporteService.ts
+++ b/frontend/modules/gestion_huerta/services/reporteService.ts
@@ -1,0 +1,30 @@
+// frontend/modules/gestion_huerta/services/reporteService.ts
+import apiClient from '../../../src/global/api/apiClient';
+import { ReporteContrato } from '../types/reportTypes';
+
+export const reporteService = {
+  async getCosecha(id: number): Promise<ReporteContrato> {
+    const { data } = await apiClient.get<{
+      success: boolean;
+      data: ReporteContrato;
+    }>(`/huerta/informes/cosechas/${id}/`);
+    return data.data;
+  },
+
+  async getTemporada(id: number): Promise<ReporteContrato> {
+    const { data } = await apiClient.get<{
+      success: boolean;
+      data: ReporteContrato;
+    }>(`/huerta/informes/temporadas/${id}/`);
+    return data.data;
+  },
+
+  async getHuertaPerfil(id: number): Promise<ReporteContrato> {
+    const { data } = await apiClient.get<{
+      success: boolean;
+      data: ReporteContrato;
+    }>(`/huerta/informes/huertas/${id}/perfil/`);
+    return data.data;
+  },
+};
+

--- a/frontend/modules/gestion_huerta/types/reportTypes.d.ts
+++ b/frontend/modules/gestion_huerta/types/reportTypes.d.ts
@@ -1,0 +1,38 @@
+// frontend/modules/gestion_huerta/types/reportTypes.d.ts
+
+export interface KPI {
+  id: string;
+  label: string;
+  value: number;
+  hint?: string;
+}
+
+export interface SeriePoint {
+  x: string | number;
+  y: number;
+}
+
+export interface Serie {
+  id: string;
+  label: string;
+  type: 'bar' | 'line';
+  data: SeriePoint[];
+}
+
+export interface TablaColumn {
+  id: string;
+  label: string;
+  align?: 'left' | 'right' | 'center';
+}
+
+export interface Tabla {
+  columns: TablaColumn[];
+  rows: Record<string, any>[];
+}
+
+export interface ReporteContrato {
+  kpis: KPI[];
+  series: Serie[];
+  tabla: Tabla;
+}
+

--- a/frontend/src/global/routes/moduleRoutes.ts
+++ b/frontend/src/global/routes/moduleRoutes.ts
@@ -65,6 +65,13 @@ export const moduleRoutes: ModuleRoute[] = [
     element: lazyRoute(() => import('../../modules/gestion_huerta/pages/Cosechas')),
   },
 
+  {
+    path: '/reportes',
+    module: 'gestion_huerta',
+    allowedRoles: ['admin', 'usuario'],
+    element: lazyRoute(() => import('../../modules/gestion_huerta/pages/Reportes')),
+  },
+
   // 👉 NUEVA RUTA: Finanzas por Cosecha
   {
     // antes: '/finanzas'

--- a/frontend/src/modules/gestion_huerta/components/common/ActionsMenu.tsx
+++ b/frontend/src/modules/gestion_huerta/components/common/ActionsMenu.tsx
@@ -20,6 +20,7 @@ import EventNoteIcon from '@mui/icons-material/EventNote';
 import DoneAllIcon from '@mui/icons-material/DoneAll';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import AgricultureIcon from '@mui/icons-material/Agriculture';
+import AssessmentIcon from '@mui/icons-material/Assessment';
 
 type Perm = string | string[] | undefined;
 
@@ -47,6 +48,10 @@ interface ActionsMenuProps {
   // Navegar a cosechas
   onCosechas?: () => void;
   permCosechas?: Perm;
+
+  // Generar reportes
+  onReporte?: () => void;
+  permReporte?: Perm;
 }
 
 const ActionsMenu: React.FC<ActionsMenuProps> = ({
@@ -71,6 +76,8 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({
   permTemporadas,
   onCosechas,
   permCosechas,
+  onReporte,
+  permReporte,
 }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const openMenu = (e: React.MouseEvent<HTMLElement>) => setAnchorEl(e.currentTarget);
@@ -171,6 +178,25 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({
                       <AgricultureIcon fontSize="small" />
                     </ListItemIcon>
                     <ListItemText primary="Ver cosechas" />
+                  </MenuItem>
+                </span>
+              </Tooltip>
+            );
+          })()
+        )}
+
+        {/* Reporte */}
+        {onReporte && (
+          (() => {
+            const allowed = hasPerm(permReporte);
+            return (
+              <Tooltip title={allowed ? '' : 'No tienes permiso'} disableHoverListener={allowed}>
+                <span style={{ display: 'block' }}>
+                  <MenuItem disabled={!allowed} onClick={() => handle(onReporte)}>
+                    <ListItemIcon>
+                      <AssessmentIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Reporte" />
                   </MenuItem>
                 </span>
               </Tooltip>

--- a/frontend/src/modules/gestion_huerta/components/cosecha/CosechaTable.tsx
+++ b/frontend/src/modules/gestion_huerta/components/cosecha/CosechaTable.tsx
@@ -1,6 +1,8 @@
 // src/modules/gestion_huerta/components/cosecha/CosechaTable.tsx
+// Reportes de Producción - generado por asistente IA (enero 2025)
 import React from 'react';
 import { Chip, Box } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import { TableLayout, Column } from '../../../../components/common/TableLayout';
 import { Cosecha } from '../../types/cosechaTypes';
 import ActionsMenu from '../common/ActionsMenu';
@@ -74,7 +76,9 @@ const CosechaTable: React.FC<Props> = ({
   data, page, pageSize, count, onPageChange,
   onRename, onDelete, onArchive, onRestore, onToggleFinalizada, onVerFinanzas,
   emptyMessage, loading,
-}) => (
+}) => {
+  const navigate = useNavigate();
+  return (
   <TableLayout<Cosecha>
     data={data}
     page={page}
@@ -106,6 +110,8 @@ const CosechaTable: React.FC<Props> = ({
             permArchiveOrRestore={['archive_cosecha', 'restore_cosecha']}
             permDelete="delete_cosecha"
             permFinalize={['finalize_cosecha', 'change_cosecha']}
+            onReporte={() => navigate('/reportes', { state: { tipo: 'cosecha', id: c.id } })}
+            permReporte="view_reportes"
           />
           <PermissionButton
             perm="view_inversioneshuerta"
@@ -120,6 +126,7 @@ const CosechaTable: React.FC<Props> = ({
       );
     }}
   />
-);
+  );
+};
 
 export default CosechaTable;

--- a/frontend/src/modules/gestion_huerta/components/huerta/HuertaTable.tsx
+++ b/frontend/src/modules/gestion_huerta/components/huerta/HuertaTable.tsx
@@ -1,6 +1,8 @@
 // src/modules/gestion_huerta/components/huerta/HuertaTable.tsx
+// Reportes de Producción - generado por asistente IA (enero 2025)
 import React from 'react';
 import { Chip, Tooltip, Button } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import { TableLayout, Column, FilterConfig } from '../../../../components/common/TableLayout';
 import { Huerta } from '../../types/huertaTypes';
 import { HuertaRentada } from '../../types/huertaRentadaTypes';
@@ -100,7 +102,9 @@ const HuertaTable: React.FC<Props> = ({
   filterValues,
   onFilterChange,
   limpiarFiltros
-}) => (
+}) => {
+  const navigate = useNavigate();
+  return (
   <TableLayout<Registro>
     data={data}
     page={page}
@@ -147,10 +151,13 @@ const HuertaTable: React.FC<Props> = ({
           permArchiveOrRestore={permArchiveOrRestore}
           permDelete={permDelete}
           permTemporadas="view_temporada"
+          onReporte={() => navigate('/reportes', { state: { tipo: 'huerta', id: h.id } })}
+          permReporte="view_reportes"
         />
       );
     }}
   />
-);
+  );
+};
 
 export default HuertaTable;

--- a/frontend/src/modules/gestion_huerta/components/temporada/TemporadaTable.tsx
+++ b/frontend/src/modules/gestion_huerta/components/temporada/TemporadaTable.tsx
@@ -1,6 +1,8 @@
+// Reportes de Producción - generado por asistente IA (enero 2025)
 // src/modules/gestion_huerta/components/temporada/TemporadaTable.tsx
 import React from 'react';
 import { Chip } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import { TableLayout, Column } from '../../../../components/common/TableLayout';
 import ActionsMenu from '../common/ActionsMenu';
 import { Temporada } from '../../types/temporadaTypes';
@@ -112,7 +114,9 @@ const TemporadaTable: React.FC<Props> = ({
 
   // 👇 NUEVO
   onCosechas,
-}) => (
+}) => {
+  const navigate = useNavigate();
+  return (
   <TableLayout<Temporada>
     data={data}
     page={page}
@@ -152,10 +156,13 @@ const TemporadaTable: React.FC<Props> = ({
           // 👇 NUEVOS props para “Ver cosechas”
           onCosechas={() => onCosechas(t)}
           permCosechas="view_cosecha"
+          onReporte={() => navigate('/reportes', { state: { tipo: 'temporada', id: t.id } })}
+          permReporte="view_reportes"
         />
       );
     }}
   />
-);
+  );
+};
 
 export default TemporadaTable;

--- a/frontend/src/modules/gestion_huerta/pages/Reportes.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Reportes.tsx
@@ -1,0 +1,21 @@
+// Reportes de Producción - generado por asistente IA (enero 2025)
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+const Reportes: React.FC = () => {
+  const location = useLocation() as { state?: { tipo?: string; id?: number } };
+  const { tipo, id } = location.state || {};
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h2>Reporte de producción</h2>
+      {tipo && id ? (
+        <p>Vista preliminar para {tipo} con ID {id}</p>
+      ) : (
+        <p>Seleccione un elemento desde las tablas para generar su reporte.</p>
+      )}
+    </div>
+  );
+};
+
+export default Reportes;


### PR DESCRIPTION
## Summary
- auto generate reports when navigating from tables and honor initial state
- allow report toolbar to preload type and id

## Testing
- `pytest -q` *(fails: Requested setting REST_FRAMEWORK, but settings are not configured)*
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a808af9438832c8ae3c70d889c9999