### PR TITLE
Refactor report pages to use route params

### DIFF
--- a/frontend/src/modules/gestion_huerta/pages/ReporteCosecha.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/ReporteCosecha.tsx
@@ -1,6 +1,6 @@
 // frontend/src/modules/gestion_huerta/pages/ReporteCosecha.tsx
 import { useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { Box, Typography, Divider, Alert, CircularProgress } from '@mui/material';
 import ReportesProduccionToolbar from '../components/reportes/common/ReportesProduccionToolbar';
 import ReporteProduccionViewer from '../components/reportes/common/ReporteProduccionViewer';
@@ -9,8 +9,8 @@ import { reportesProduccionService } from '../services/reportesProduccionService
 import { FormatoReporte } from '../types/reportesProduccionTypes';
 
 export default function ReporteCosecha() {
-  const [params] = useSearchParams();
-  const id = useMemo(() => Number(params.get('id') || ''), [params]);
+  const { cosechaId } = useParams<{ cosechaId: string }>();
+  const id = useMemo(() => Number(cosechaId), [cosechaId]);
 
   const [filters, setFilters] = useState<{ from?: string; to?: string; formato: FormatoReporte }>({
     formato: 'json'
@@ -45,7 +45,7 @@ export default function ReporteCosecha() {
         onExport={handleExport}
       />
       <Divider sx={{ my: 2 }} />
-      {!id && <Alert severity="info">Proporcione ?id=&lt;cosechaId&gt; en la URL.</Alert>}
+      {!id && <Alert severity="info">Proporcione un cosechaId en la URL.</Alert>}
       {loading && <CircularProgress size={24} />}
       {error && <Alert severity="error">{error}</Alert>}
       {data && <ReporteProduccionViewer data={data} title="Reporte de Cosecha" />}

--- a/frontend/src/modules/gestion_huerta/pages/ReporteHuertaPerfil.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/ReporteHuertaPerfil.tsx
@@ -1,6 +1,6 @@
 // frontend/src/modules/gestion_huerta/pages/ReporteHuertaPerfil.tsx
 import { useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { Box, Typography, Divider, Alert, CircularProgress } from '@mui/material';
 import ReportesProduccionToolbar from '../components/reportes/common/ReportesProduccionToolbar';
 import ReporteProduccionViewer from '../components/reportes/common/ReporteProduccionViewer';
@@ -9,8 +9,8 @@ import { reportesProduccionService } from '../services/reportesProduccionService
 import { FormatoReporte } from '../types/reportesProduccionTypes';
 
 export default function ReporteHuertaPerfil() {
-  const [params] = useSearchParams();
-  const id = useMemo(() => Number(params.get('id') || ''), [params]);
+  const { huertaId } = useParams<{ huertaId: string }>();
+  const id = useMemo(() => Number(huertaId), [huertaId]);
 
   const [filters, setFilters] = useState<{ from?: string; to?: string; formato: FormatoReporte }>({
     formato: 'json'
@@ -45,7 +45,7 @@ export default function ReporteHuertaPerfil() {
         onExport={handleExport}
       />
       <Divider sx={{ my: 2 }} />
-      {!id && <Alert severity="info">Proporcione ?id=&lt;huertaId&gt; en la URL.</Alert>}
+      {!id && <Alert severity="info">Proporcione un huertaId en la URL.</Alert>}
       {loading && <CircularProgress size={24} />}
       {error && <Alert severity="error">{error}</Alert>}
       {data && <ReporteProduccionViewer data={data} title="Perfil Histórico de Huerta" />}

--- a/frontend/src/modules/gestion_huerta/pages/ReporteTemporada.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/ReporteTemporada.tsx
@@ -1,6 +1,6 @@
 // frontend/src/modules/gestion_huerta/pages/ReporteTemporada.tsx
 import { useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { Box, Typography, Divider, Alert, CircularProgress } from '@mui/material';
 import ReportesProduccionToolbar from '../components/reportes/common/ReportesProduccionToolbar';
 import ReporteProduccionViewer from '../components/reportes/common/ReporteProduccionViewer';
@@ -9,8 +9,8 @@ import { reportesProduccionService } from '../services/reportesProduccionService
 import { FormatoReporte } from '../types/reportesProduccionTypes';
 
 export default function ReporteTemporada() {
-  const [params] = useSearchParams();
-  const id = useMemo(() => Number(params.get('id') || ''), [params]);
+  const { temporadaId } = useParams<{ temporadaId: string }>();
+  const id = useMemo(() => Number(temporadaId), [temporadaId]);
 
   const [filters, setFilters] = useState<{ from?: string; to?: string; formato: FormatoReporte }>({
     formato: 'json'
@@ -45,7 +45,7 @@ export default function ReporteTemporada() {
         onExport={handleExport}
       />
       <Divider sx={{ my: 2 }} />
-      {!id && <Alert severity="info">Proporcione ?id=&lt;temporadaId&gt; en la URL.</Alert>}
+      {!id && <Alert severity="info">Proporcione un temporadaId en la URL.</Alert>}
       {loading && <CircularProgress size={24} />}
       {error && <Alert severity="error">{error}</Alert>}
       {data && <ReporteProduccionViewer data={data} title="Reporte de Temporada" />}


### PR DESCRIPTION
## Summary
- replace useSearchParams with useParams in report pages
- compute report IDs from route params
- keep export functions using numeric IDs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any errors)


------
https://chatgpt.com/codex/tasks/task_e_68a867fd4574832cac6422edfcce1389