### PR TITLE
refactor: update report routes

### DIFF
--- a/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Cosechas.tsx
@@ -233,7 +233,13 @@ useEffect(() => {
   // Navegar a Reporte de Cosecha
   const handleReporteCosecha = (c: Cosecha) => {
     if (!tempInfo) return;
-    navigate(`/reporte-cosecha/${c.id}?temporada_id=${temporadaId}&huerta_id=${tempInfo.huerta_id}&año=${tempInfo.año}&huerta_nombre=${encodeURIComponent(tempInfo.huerta_nombre || '')}`);
+    const params = new URLSearchParams({
+      temporada_id: String(temporadaId),
+      huerta_id: String(tempInfo.huerta_id),
+      año: String(tempInfo.año),
+    });
+    if (tempInfo.huerta_nombre) params.set('huerta_nombre', tempInfo.huerta_nombre);
+    navigate(`/reportes/cosecha/${c.id}?${params.toString()}`);
   };
 
   const clearFilters = () => {

--- a/frontend/src/modules/gestion_huerta/pages/Huertas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Huertas.tsx
@@ -281,7 +281,13 @@ const Huertas: React.FC = () => {
             onArchive={h => handleArchiveOrRestore(h, false)}
             onRestore={h => handleArchiveOrRestore(h, true)}
             onTemporadas={h => navigate(`/temporadas?huerta_id=${h.id}&tipo=${isRentada(h) ? 'rentada' : 'propia'}`)}
-            onReporteHuerta={h => navigate(`/reporte-huerta-perfil/${h.id}?tipo=${isRentada(h) ? 'rentada' : 'propia'}&huerta_nombre=${encodeURIComponent(h.nombre || '')}`)}
+            onReporteHuerta={h => {
+              const params = new URLSearchParams({
+                tipo: isRentada(h) ? 'rentada' : 'propia',
+              });
+              if (h.nombre) params.set('huerta_nombre', h.nombre);
+              navigate(`/reportes/huerta/${h.id}/perfil?${params.toString()}`);
+            }}
           />
         </Box>
 

--- a/frontend/src/modules/gestion_huerta/pages/Temporadas.tsx
+++ b/frontend/src/modules/gestion_huerta/pages/Temporadas.tsx
@@ -335,7 +335,12 @@ const Temporadas: React.FC = () => {
   };
 
   const handleReporteTemporada = (t: Temporada) => {
-    navigate(`/reporte-temporada/${t.id}?huerta_id=${huertaId}&año=${t.año}&huerta_nombre=${encodeURIComponent(displayHuertaNombre || '')}&tipo=${tipo || ''}&propietario=${encodeURIComponent(displayPropietario || '')}`);
+    const params = new URLSearchParams({ año: String(t.año) });
+    if (huertaId) params.set('huerta_id', String(huertaId));
+    if (displayHuertaNombre) params.set('huerta_nombre', displayHuertaNombre);
+    if (tipo) params.set('tipo', tipo);
+    if (displayPropietario) params.set('propietario', displayPropietario);
+    navigate(`/reportes/temporada/${t.id}?${params.toString()}`);
   };
 
   // Limpiar todos los filtros (excepto estado)


### PR DESCRIPTION
## Summary
- update report navigation routes for cosechas, temporadas, and huertas
- build query strings with `URLSearchParams`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 249 errors, 16 warnings)*
- `npm run build` *(fails: TS2339, TS2307, TS7006 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a867fc2fe4832cb3e443ac5358ca70